### PR TITLE
Unpin ocaml-crc on trunk

### DIFF
--- a/SPECS/ocaml-crc.spec
+++ b/SPECS/ocaml-crc.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:           ocaml-crc
-Version:        0.9.1
+Version:        1.0.0
 Release:        1%{?dist}
 Summary:        CRC implementation for OCaml
 License:        ISC
@@ -57,6 +57,9 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/crc/libcrc_stubs.a
 
 %changelog
+* Wed Apr 13 2016 Si Beaumont <simon.beaumont@citrix.com> - 1.0.0-1
+- Update to 1.0.0
+
 * Sat Apr 26 2014 David Scott <dave.scott@citrix.com> - 0.9.1-1
 - Update to 0.9.1
 

--- a/SPECS/ocaml-crc.spec
+++ b/SPECS/ocaml-crc.spec
@@ -42,6 +42,7 @@ export OCAMLFIND_LDCONF=%{buildroot}%{_libdir}/ocaml/ld.conf
 ocaml setup.ml -install
 
 %files
+%{_libdir}/ocaml/crc
 %{_libdir}/ocaml/crc/META
 %{_libdir}/ocaml/crc/crc.cma
 %{_libdir}/ocaml/crc/crc.cmi
@@ -55,6 +56,9 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/crc/crc.cmxs
 %{_libdir}/ocaml/crc/crc.mli
 %{_libdir}/ocaml/crc/libcrc_stubs.a
+%{_libdir}/ocaml/crc/crc.cmt
+%{_libdir}/ocaml/crc/crc.cmti
+%{_libdir}/ocaml/crc/crc.annot
 
 %changelog
 * Wed Apr 13 2016 Si Beaumont <simon.beaumont@citrix.com> - 1.0.0-1

--- a/SPECS/ocaml-shared-block-ring.spec
+++ b/SPECS/ocaml-shared-block-ring.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:           ocaml-shared-block-ring
-Version:        2.0.0
+Version:        2.1.0
 Release:        1%{?dist}
 Summary:        OCaml implementation of shared block rings
 License:        ISC
@@ -65,6 +65,9 @@ make install
 %{_libdir}/ocaml/shared-block-ring/*.mli
 
 %changelog
+* Fri Apr 15 2016 Euan Harris <euan.harris@citrix.com> - 2.1.0-1
+- Update to 2.1.0
+
 * Thu Apr 30 2015 David Scott <dave.scott@citrix.com> - 2.0.0-1
 - Update to 2.0.0
 

--- a/pins
+++ b/pins
@@ -7,9 +7,6 @@
   "SPECS/message-switch.spec": {
     "0": "/repos/message-switch#HEAD"
   },
-  "SPECS/ocaml-shared-block-ring.spec": {
-    "0": "/repos/shared-block-ring#HEAD"
-  },
   "SPECS/ocaml-stdext.spec": {
     "0": "/repos/stdext#HEAD"
   },

--- a/pins
+++ b/pins
@@ -7,9 +7,6 @@
   "SPECS/message-switch.spec": {
     "0": "/repos/message-switch#HEAD"
   },
-  "SPECS/ocaml-opasswd.spec": {
-    "0": "/repos/ocaml-opasswd#HEAD"
-  },
   "SPECS/ocaml-shared-block-ring.spec": {
     "0": "/repos/shared-block-ring#HEAD"
   },

--- a/pins
+++ b/pins
@@ -7,9 +7,6 @@
   "SPECS/message-switch.spec": {
     "0": "/repos/message-switch#HEAD"
   },
-  "SPECS/ocaml-crc.spec": {
-    "0": "/repos/ocaml-crc#HEAD"
-  },
   "SPECS/ocaml-opasswd.spec": {
     "0": "/repos/ocaml-opasswd#HEAD"
   },


### PR DESCRIPTION
This pull request ports the changes to unpin ocaml-crc on dundee-bugfix, but leaves out the reverts and reverts-of-reverts that happened on that branch.
