### PR TITLE
Revert "CP-17127: ocaml-tar: Update to 0.4.2"

### DIFF
--- a/SPECS/ocaml-tar.spec
+++ b/SPECS/ocaml-tar.spec
@@ -1,10 +1,10 @@
 Name:           ocaml-tar
-Version:        0.4.2
-Release:        1%{?dist}
+Version:        0.2.1
+Release:        2%{?dist}
 Summary:        OCaml parser and printer for tar-format data
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/mirage/ocaml-tar
-Source0:        https://github.com/mirage/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz 
+Source0:        https://github.com/mirage/%{name}/archive/%{version}/%{name}-%{version}.tar.gz 
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-ounit-devel
@@ -12,7 +12,6 @@ BuildRequires:  ocaml-cstruct-devel
 BuildRequires:  ocaml-lwt-devel
 BuildRequires:  ocaml-re-devel
 BuildRequires:  ocaml-camlp4-devel
-BuildRequires:  ocaml-mirage-types-devel
 
 %description
 This is a pure OCaml library for reading and writing tar-format data.
@@ -32,7 +31,7 @@ developing applications that use %{name}.
 %setup -q
 
 %build
-ocaml setup.ml -configure --destdir %{buildroot}%{_libdir}/ocaml --disable-mirage
+ocaml setup.ml -configure --destdir %{buildroot}%{_libdir}/ocaml
 ocaml setup.ml -build
 
 %install
@@ -56,9 +55,6 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/tar/*.mli
 
 %changelog
-* Thu Apr 28 2016 Euan Harris <euan.harris@citrix.com> - 0.4.2-1
-- Update to 0.4.2
-
 * Fri May 30 2014 Euan Harris <euan.harris@citrix.com> - 0.2.1-2
 - Split files correctly between base and devel packages
 


### PR DESCRIPTION
Revert ocaml-tar back to 0.2.1 but leave it unpinned. The update is
causing issues with VM.import. ocaml-tar can be updated again once these
issues have been fixed.

This reverts commit 2bb139814a1341823621ea3caeb938501eaeeada.
