### PR TITLE
CP-17268 New spec files for bisect_ppx and ppxtools - for coverage profiling 

### DIFF
--- a/SPECS/ocaml-bisect-ppx.spec
+++ b/SPECS/ocaml-bisect-ppx.spec
@@ -1,0 +1,53 @@
+%global debug_package %{nil}
+
+Name:           ocaml-bisect-ppx
+Version:        1.1.0
+Release:        1%{?dist}
+Summary:        A tool for code coverage profiling
+License:        GPLv3
+URL:            https://github.com/aantron/bisect_ppx
+Source0:        https://github.com/aantron/bisect_ppx/archive/%{version}/%{name}-%{version}.tar.gz     
+BuildRequires:  ocaml
+BuildRequires:  ocaml-ppxtools-devel
+BuildRequires:  ocaml-findlib
+
+%description
+A coverage profiler for OCaml projects.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q -n bisect_ppx-%{version}
+
+%build
+make build
+
+%install
+export OCAMLFIND_DESTDIR=%{buildroot}/%{_libdir}/ocaml
+mkdir -p $OCAMLFIND_DESTDIR
+make install
+
+%files
+%doc README.md
+%doc doc/*
+%{_libdir}/ocaml/bisect_ppx
+%exclude %{_libdir}/ocaml/bisect_ppx/*.a
+%exclude %{_libdir}/ocaml/bisect_ppx/*.cmxa
+%exclude %{_libdir}/ocaml/bisect_ppx/*.cmx
+# %exclude %{_libdir}/ocaml/bisect_ppx/*.mli
+
+%files devel
+%{_libdir}/ocaml/bisect_ppx/*.a
+%{_libdir}/ocaml/bisect_ppx/*.cmx
+%{_libdir}/ocaml/bisect_ppx/*.cmxa
+# %{_libdir}/ocaml/bisect_ppx/*.mli
+
+%changelog
+* Wed May 11 2016 Christian Lindig <christian.lindig@citrix.com> - 1.1.0-1
+- Initial package

--- a/SPECS/ocaml-ppxtools.spec
+++ b/SPECS/ocaml-ppxtools.spec
@@ -1,0 +1,54 @@
+%global debug_package %{nil}
+
+Name:           ocaml-ppxtools
+Version:        5.0+4.02.0
+Release:        1%{?dist}
+Summary:        A tool for code coverage profiling
+License:        MIT
+URL:            https://github.com/alainfrisch/ppx_tools
+Source0:        https://github.com/alainfrisch/ppx_tools/archive/%{version}/%{name}-%{version}.tar.gz
+BuildRequires:  ocaml
+BuildRequires:  ocaml-findlib
+
+%description
+Tools for authors of syntactic tools (such as ppx rewriters).
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and signature files for
+developing applications that use %{name}.
+
+%prep
+%setup -q -n ppx_tools-5.0-4.02.0
+
+%build
+make
+
+%install
+export OCAMLFIND_DESTDIR=%{buildroot}/%{_libdir}/ocaml
+mkdir -p $OCAMLFIND_DESTDIR
+make install
+
+
+%files
+%doc LICENSE
+%doc README.md
+%{_libdir}/ocaml/ppx_tools
+%exclude %{_libdir}/ocaml/ppx_tools/*.a
+%exclude %{_libdir}/ocaml/ppx_tools/*.cmxa
+%exclude %{_libdir}/ocaml/ppx_tools/*.cmx
+%exclude %{_libdir}/ocaml/ppx_tools/*.mli
+
+%files devel
+%{_libdir}/ocaml/ppx_tools/*.a
+%{_libdir}/ocaml/ppx_tools/*.cmx
+%{_libdir}/ocaml/ppx_tools/*.cmxa
+%{_libdir}/ocaml/ppx_tools/*.mli
+
+%changelog
+* Wed May 11 2016 Christian Lindig <christian.lindig@citrix.com> - 5.0+4.02.0-1
+- Initial package
+


### PR DESCRIPTION
`bisect_ppx` is an OCaml ppx that instruments code for coverage profiling and includes a report generator. It depends on `ppxtools`. This pull requests adds the spec files for both. `ppxtools` is intended for OCaml 4.02 (which we are currently using).
