### PR TITLE
CA-210015: patch ocaml-vhd for lseek(,,SEEK_DATA/SET) fallback

### DIFF
--- a/SOURCES/0001-Change-to-fix-XSO-518.patch
+++ b/SOURCES/0001-Change-to-fix-XSO-518.patch
@@ -1,0 +1,50 @@
+From 476f501e0d75dfba04750f3f33135e648755a5c6 Mon Sep 17 00:00:00 2001
+From: Shawn Edwards <shedwards@nvidia.com>
+Date: Mon, 2 May 2016 13:57:59 -0500
+Subject: [PATCH] Change to fix XSO-518.
+
+Tries SEEK_DATA/HOLE and falls back to SET/END at runtime instead of compile time
+---
+ lib/lseek64_stubs.c | 17 ++++++-----------
+ 1 file changed, 6 insertions(+), 11 deletions(-)
+
+diff --git a/lib/lseek64_stubs.c b/lib/lseek64_stubs.c
+index ab7e35b..35f5ef3 100644
+--- a/lib/lseek64_stubs.c
++++ b/lib/lseek64_stubs.c
+@@ -46,12 +46,10 @@ CAMLprim value stub_lseek64_data(value fd, value ofs) {
+   off_t c_ret;
+ 
+   caml_enter_blocking_section();
+-#if defined(SEEK_DATA)
+   c_ret = lseek(c_fd, c_ofs, SEEK_DATA);
+-#else
+-  /* Set the file pointer to ofs; pretend there is data */
+-  c_ret = lseek(c_fd, c_ofs, SEEK_SET);
+-#endif
++  /* If there is no SEEK_DATA support, 
++     set the file pointer to ofs; pretend there is data */
++  if (c_ret == -1) c_ret = lseek(c_fd, c_ofs, SEEK_SET);
+   caml_leave_blocking_section();
+   if (c_ret == -1) uerror("lseek", Nothing);
+ 
+@@ -67,13 +65,10 @@ CAMLprim value stub_lseek64_hole(value fd, value ofs) {
+   off_t c_ret;
+ 
+   caml_enter_blocking_section();
+-#if defined(SEEK_HOLE)
+   c_ret = lseek(c_fd, c_ofs, SEEK_HOLE);
+-#else
+-  /* Set the file pointer to the end of the file; pretend
+-     there is no hole */
+-  c_ret = lseek(c_fd, 0, SEEK_END);
+-#endif
++  /* If there is no SEEK_HOLE support, set the file pointer 
++     to the end of the file; pretend there is no hole */
++  if (c_ret == -1) c_ret = lseek(c_fd, 0, SEEK_END);
+   caml_leave_blocking_section();
+   if (c_ret == -1) uerror("lseek", Nothing);
+   result = caml_copy_int64(c_ret);
+-- 
+2.8.1
+

--- a/SPECS/ocaml-vhd.spec
+++ b/SPECS/ocaml-vhd.spec
@@ -2,11 +2,12 @@
 
 Name:           ocaml-vhd
 Version:        0.7.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Pure OCaml library for reading, writing, streaming, converting vhd format files
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/djs55/ocaml-vhd
 Source0:        https://github.com/djs55/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
+Patch0:         0001-Change-to-fix-XSO-518.patch
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-cstruct-devel
@@ -45,6 +46,7 @@ developing applications that use %{name}.
 
 %prep
 %setup -q
+%patch0 -p1
 
 %build
 if [ -x ./configure ]; then
@@ -80,6 +82,11 @@ ocaml setup.ml -install
 
 
 %changelog
+* Tue May 24 2016 Christian Lindig <christian.lindig@citrix.com> - 0.7.3-2
+- Applied patch https://github.com/djs55/ocaml-vhd/pull/33 for
+  runtime support of filesystems without SEEK_DATA support. When lseek
+  fails, it is tried again with SEEK_SET.
+
 * Thu Apr 21 2016 Euan Harris <euan.harris@citrix.com> - 0.7.3-1
 - Update to 0.7.3
 


### PR DESCRIPTION
This patch adds a fallback if lseek(2) doesn't support SEEK_DATA.

Signed-off-by: Christian Lindig christian.lindig@citrix.com
