### PR TITLE
add bisect-summary CP-17569

### DIFF
--- a/SPECS/ocaml-bisect-summary.spec
+++ b/SPECS/ocaml-bisect-summary.spec
@@ -1,11 +1,11 @@
 Name:           ocaml-bisect-summary
-Version:        0.4
+Version:        0.5
 Release:        1%{?dist}
 Summary:        Report code coverage from bisect_ppx runtime files
 License:        MIT
 URL:            https://github.com/lindig/bisect-summary
 Source0:        https://github.com/lindig/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
-BuildRequires:  oasis-devel
+BuildRequires:  oasis
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-bisect-ppx-devel
@@ -35,5 +35,6 @@ make install
 
 
 %changelog
+* Tue Jun  7 2016 Christian Lindig <christian.lindig@citrix.com> - 0.5-1
 * Fri Jun  3 2016 Christian Lindig <christian.lindig@citrix.com> - 0.4-1
   Initial packaging

--- a/SPECS/ocaml-bisect-summary.spec
+++ b/SPECS/ocaml-bisect-summary.spec
@@ -1,0 +1,41 @@
+%global debug_package %{nil}
+
+Name:           ocaml-bisect-summary
+Version:        0.4
+Release:        1%{?dist}
+Summary:        Report code coverage from bisect_ppx runtime files
+License:        LGPL
+URL:            https://github.com/lindig/bisect-summary
+Source0:        https://github.com/lindig/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+BuildRequires:  oasis-devel
+BuildRequires:  ocaml
+BuildRequires:  ocaml-findlib
+BuildRequires:  ocaml-bisect-ppx-devel
+
+%description
+
+Bisect-summary reads bisect*.out files produced by code that was
+instrumented with bisect_ppx for code coverage profiling. Unlike
+bisect-ppx-report (the canonical tool), this tool only needs the files
+produced at runtime and doesn't require access to the source code and
+point files that bisect_ppx produces at compile time.
+
+%prep
+%setup -q -n bisect-summary-%{version}
+
+%build
+ocaml setup.ml -configure --prefix /usr --destdir %{buildroot}
+make
+
+%install
+make install
+
+%files
+%doc LICENSE
+%doc README.md
+%{_bindir}/bisect-summary
+
+
+%changelog
+* Wed Jun  1 2016 Christian Lindig <christian.lindig@citrix.com> - 0.4-1
+  Initial packaging

--- a/SPECS/ocaml-bisect-summary.spec
+++ b/SPECS/ocaml-bisect-summary.spec
@@ -1,0 +1,40 @@
+
+Name:           ocaml-bisect-summary
+Version:        0.4
+Release:        1%{?dist}
+Summary:        Report code coverage from bisect_ppx runtime files
+License:        LGPL
+URL:            https://github.com/lindig/bisect-summary
+Source0:        https://github.com/lindig/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+BuildRequires:  oasis-devel
+BuildRequires:  ocaml
+BuildRequires:  ocaml-findlib
+BuildRequires:  ocaml-bisect-ppx-devel
+
+%description
+
+Bisect-summary reads bisect*.out files produced by code that was
+instrumented with bisect_ppx for code coverage profiling. Unlike
+bisect-ppx-report (the canonical tool), this tool only needs the files
+produced at runtime and doesn't require access to the source code and
+point files that bisect_ppx produces at compile time.
+
+%prep
+%setup -q -n bisect-summary-%{version}
+
+%build
+ocaml setup.ml -configure --prefix /usr --destdir %{buildroot}
+make
+
+%install
+make install
+
+%files
+%doc LICENSE
+%doc README.md
+%{_bindir}/bisect-summary
+
+
+%changelog
+* Fri Jun  3 2016 Christian Lindig <christian.lindig@citrix.com> - 0.4-1
+  Initial packaging

--- a/SPECS/ocaml-bisect-summary.spec
+++ b/SPECS/ocaml-bisect-summary.spec
@@ -5,7 +5,7 @@ Summary:        Report code coverage from bisect_ppx runtime files
 License:        MIT
 URL:            https://github.com/lindig/bisect-summary
 Source0:        https://github.com/lindig/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
-BuildRequires:  oasis
+BuildRequires:  oasis-devel
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib
 BuildRequires:  ocaml-bisect-ppx-devel


### PR DESCRIPTION
bisect-summary is a tool to obtain code coverage data from test runs that were instrumented with ocaml-bisect-ppx. Unlike the canonical tool bisect-ppx-report, this one only requires the data produced at runtime and no files from compilation time. It hence is simpler to use for other teams.

Signed-off-by: Christian Lindig christian.lindig@citrix.com
