### PR TITLE
bisect-summary: Fix source URL

### DIFF
--- a/SPECS/ocaml-bisect-summary.spec
+++ b/SPECS/ocaml-bisect-summary.spec
@@ -4,7 +4,7 @@ Release:        1%{?dist}
 Summary:        Report code coverage from bisect_ppx runtime files
 License:        MIT
 URL:            https://github.com/lindig/bisect-summary
-Source0:        https://github.com/lindig/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/lindig/bisect-summary/archive/%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  oasis
 BuildRequires:  ocaml
 BuildRequires:  ocaml-findlib


### PR DESCRIPTION
The repository name is bisect-summary, not ocaml-bisect summary.

Signed-off-by: Euan Harris euan.harris@citrix.com
