### PR TITLE
ocaml-xcp-idl: bump version after interface changed to xenopsd

### DIFF
--- a/SPECS/ocaml-xcp-idl.spec
+++ b/SPECS/ocaml-xcp-idl.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ocaml-xcp-idl
-Version:        1.1.0
+Version:        1.3.0
 Release:        1%{?dist}
 Summary:        Common interface definitions for XCP services
 License:        LGPL
@@ -74,6 +74,9 @@ make install
 %{_libdir}/ocaml/xcp/*.mli
 
 %changelog
+* Wed Aug 17 2016 Christian Lindig <christian.lindig@citrix.com> - 1.3.0-1
+- Update to 1.3.0; the interface to xenopsd changed
+
 * Mon Jul 4 2016 Euan Harris <euan.harris@citrix.com> - 1.1.0-1
 - Update to 1.1.0
 


### PR DESCRIPTION
xenopsd and xcp-idl widened their interface and this commit documents this with a version bump. 

Signed-off-by: Christian Lindig christian.lindig@citrix.com
