### PR TITLE
Sync baggage

### DIFF
--- a/SPECS/ocaml-async-extra.spec
+++ b/SPECS/ocaml-async-extra.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-async-extra
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jane Street Capital's asynchronous execution library (core)
 
 Group:          Development/Libraries
@@ -99,6 +99,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/async_extra/*.ml
 %exclude %{_libdir}/ocaml/async_extra/*.mli
+%exclude %{_libdir}/ocaml/async_extra/*.annot
+%exclude %{_libdir}/ocaml/async_extra/*.cmt
+%exclude %{_libdir}/ocaml/async_extra/*.cmti
 
 %files devel
 %defattr(-,root,root,-)
@@ -111,6 +114,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/async_extra/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-async-find.spec
+++ b/SPECS/ocaml-async-find.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-async-find
 Version:        111.28.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jane Street Capital's asynchronous execution library (core)
 
 Group:          Development/Libraries
@@ -85,6 +85,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/async_find/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/async_find/*.mli
+%exclude %{_libdir}/ocaml/async_find/*.annot
+%exclude %{_libdir}/ocaml/async_find/*.cmt
+%exclude %{_libdir}/ocaml/async_find/*.cmti
 
 %files devel
 %defattr(-,root,root,-)
@@ -96,6 +99,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/async_find/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 111.28.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 111.28.00-1
 - Update to 111.28.00
 

--- a/SPECS/ocaml-async-inotify.spec
+++ b/SPECS/ocaml-async-inotify.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-async-inotify
 Version:        111.28.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jane Street Capital's asynchronous execution library (core)
 
 Group:          Development/Libraries
@@ -96,6 +96,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/async_inotify/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/async_inotify/*.mli
+%exclude %{_libdir}/ocaml/async_inotify/*.annot
+%exclude %{_libdir}/ocaml/async_inotify/*.cmt
+%exclude %{_libdir}/ocaml/async_inotify/*.cmti
 
 %files devel
 %defattr(-,root,root,-)
@@ -107,6 +110,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/async_inotify/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 111.28.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 111.28.00-1
 - Update to 111.28.00
 

--- a/SPECS/ocaml-async-kernel.spec
+++ b/SPECS/ocaml-async-kernel.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-async-kernel
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Monad concurrency library
 
 Group:          Development/Libraries
@@ -101,6 +101,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/async_kernel/*.ml
 %exclude %{_libdir}/ocaml/async_kernel/*.mli
+%exclude %{_libdir}/ocaml/async_kernel/*.annot
+%exclude %{_libdir}/ocaml/async_kernel/*.cmt
+%exclude %{_libdir}/ocaml/async_kernel/*.cmti
 
 %files devel
 %defattr(-,root,root,-)
@@ -113,6 +116,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/async_kernel/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-async-rpc-kernel.spec
+++ b/SPECS/ocaml-async-rpc-kernel.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-async-rpc-kernel
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Platform-independent core of Async RPC library
 
 Group:          Development/Libraries
@@ -99,6 +99,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/async_rpc_kernel/*.ml
 %exclude %{_libdir}/ocaml/async_rpc_kernel/*.mli
+%exclude %{_libdir}/ocaml/async_rpc_kernel/*.annot
+%exclude %{_libdir}/ocaml/async_rpc_kernel/*.cmt
+%exclude %{_libdir}/ocaml/async_rpc_kernel/*.cmti
 
 %files devel
 %defattr(-,root,root,-)
@@ -111,6 +114,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/async_rpc_kernel/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-async-unix.spec
+++ b/SPECS/ocaml-async-unix.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-async-unix
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jane Street Capital's asynchronous execution library (core)
 
 Group:          Development/Libraries
@@ -95,6 +95,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/async_unix/*.ml
 %exclude %{_libdir}/ocaml/async_unix/*.mli
+%exclude %{_libdir}/ocaml/async_unix/*.annot
+%exclude %{_libdir}/ocaml/async_unix/*.cmt
+%exclude %{_libdir}/ocaml/async_unix/*.cmti
 
 %files devel
 %defattr(-,root,root,-)
@@ -107,6 +110,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/async_unix/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-async.spec
+++ b/SPECS/ocaml-async.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-async
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jane Street Capital's asynchronous execution library (core)
 
 Group:          Development/Libraries
@@ -97,6 +97,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/async/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/async/*.ml
+%exclude %{_libdir}/ocaml/async/*.annot
+%exclude %{_libdir}/ocaml/async/*.cmt
+%exclude %{_libdir}/ocaml/async/*.cmti
 
 %files devel
 %defattr(-,root,root,-)
@@ -108,6 +111,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/async/*.ml
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-base64.spec
+++ b/SPECS/ocaml-base64.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-base64
 Version:        2.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Base64 encoding and decoding library
 License:        ISC
 URL:            https://github.com/mirage/ocaml-base64
@@ -49,6 +49,9 @@ ocaml setup.ml -install
 %exclude %{_libdir}/ocaml/base64/*.cmxa
 %exclude %{_libdir}/ocaml/base64/*.cmx
 %exclude %{_libdir}/ocaml/base64/*.mli
+%exclude %{_libdir}/ocaml/base64/*.annot
+%exclude %{_libdir}/ocaml/base64/*.cmt
+%exclude %{_libdir}/ocaml/base64/*.cmti
 
 %files devel
 %{_libdir}/ocaml/base64/*.a
@@ -57,5 +60,8 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/base64/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.0.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Apr  2 2015 David Scott <dave.scott@citrix.com> - 2.0.0-1
 - Initial package

--- a/SPECS/ocaml-bin-prot.spec
+++ b/SPECS/ocaml-bin-prot.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-bin-prot
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Read and write OCaml values in a type-safe binary protocol
 
 Group:          Development/Libraries
@@ -92,6 +92,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/bin_prot/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/bin_prot/*.mli
+%exclude %{_libdir}/ocaml/bin_prot/*.annot
+%exclude %{_libdir}/ocaml/bin_prot/*.cmt
+%exclude %{_libdir}/ocaml/bin_prot/*.cmti
 %{_libdir}/ocaml/stublibs/*.so
 %{_libdir}/ocaml/stublibs/*.so.owner
 
@@ -107,6 +110,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-biniou.spec
+++ b/SPECS/ocaml-biniou.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-biniou
 Version:        1.0.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Compact, fast and extensible serialization format
 License:        BSD3
 URL:            http://mjambon.com/biniou.html
@@ -46,6 +46,9 @@ make install BINDIR=%{buildroot}/%{_bindir}
 %exclude %{_libdir}/ocaml/biniou/*.cmxa
 %exclude %{_libdir}/ocaml/biniou/*.cmx
 %exclude %{_libdir}/ocaml/biniou/*.mli
+%exclude %{_libdir}/ocaml/biniou/*.annot
+%exclude %{_libdir}/ocaml/biniou/*.cmt
+%exclude %{_libdir}/ocaml/biniou/*.cmti
 
 %files devel
 %{_libdir}/ocaml/biniou/*.a
@@ -54,6 +57,9 @@ make install BINDIR=%{buildroot}/%{_bindir}
 %{_libdir}/ocaml/biniou/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.0.6-4
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 21 2014 Euan Harris <euan.harris@citrix.com> - 1.0.6-3
 - Switch to GitHub sources
 

--- a/SPECS/ocaml-bisect-ppx.spec
+++ b/SPECS/ocaml-bisect-ppx.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-bisect-ppx
 Version:        1.1.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A tool for code coverage profiling
 License:        GPLv3
 URL:            https://github.com/aantron/bisect_ppx
@@ -41,6 +41,9 @@ make install
 %exclude %{_libdir}/ocaml/bisect_ppx/*.cmxa
 %exclude %{_libdir}/ocaml/bisect_ppx/*.cmx
 # %exclude %{_libdir}/ocaml/bisect_ppx/*.mli
+%exclude %{_libdir}/ocaml/bisect_ppx/*.annot
+%exclude %{_libdir}/ocaml/bisect_ppx/*.cmt
+%exclude %{_libdir}/ocaml/bisect_ppx/*.cmti
 
 %files devel
 %{_libdir}/ocaml/bisect_ppx/*.a
@@ -49,5 +52,8 @@ make install
 # %{_libdir}/ocaml/bisect_ppx/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.1.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed May 11 2016 Christian Lindig <christian.lindig@citrix.com> - 1.1.0-1
 - Initial package

--- a/SPECS/ocaml-bitstring.spec
+++ b/SPECS/ocaml-bitstring.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-bitstring
 Version:        2.0.4
-Release:        13%{?dist}
+Release:        14%{?dist}
 Summary:        OCaml library for matching and constructing bitstrings
 License:        LGPLv2+ with exceptions and GPLv2+
 
@@ -105,6 +105,9 @@ install -m 0755 bitstring-objinfo $RPM_BUILD_ROOT%{_bindir}
 %exclude %{_libdir}/ocaml/bitstring/*.cmx
 %endif
 %exclude %{_libdir}/ocaml/bitstring/*.mli
+%exclude %{_libdir}/ocaml/bitstring/*.annot
+%exclude %{_libdir}/ocaml/bitstring/*.cmt
+%exclude %{_libdir}/ocaml/bitstring/*.cmti
 %{_libdir}/ocaml/stublibs/*.so
 %{_libdir}/ocaml/stublibs/*.so.owner
 
@@ -121,6 +124,9 @@ install -m 0755 bitstring-objinfo $RPM_BUILD_ROOT%{_bindir}
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.0.4-14
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed Jun 24 2015 Richard W.M. Jones <rjones@redhat.com> - 2.0.4-13
 - ocaml-4.02.2 final rebuild.
 

--- a/SPECS/ocaml-bitstring.spec
+++ b/SPECS/ocaml-bitstring.spec
@@ -7,7 +7,7 @@ Summary:        OCaml library for matching and constructing bitstrings
 License:        LGPLv2+ with exceptions and GPLv2+
 
 URL:            http://code.google.com/p/bitstring/
-Source0:        http://bitstring.googlecode.com/files/%{name}-%{version}.tar.gz
+Source0:        https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/bitstring/%{name}-%{version}.tar.gz
 
 # Upstream patch to enable debugging.
 Patch1:         bitstring-r201.patch
@@ -124,6 +124,9 @@ install -m 0755 bitstring-objinfo $RPM_BUILD_ROOT%{_bindir}
 
 
 %changelog
+* Wed Aug 31 2016 Euan Harris <euan.harris@citrix.com> - 2.0.4-15
+- Fix source URL
+
 * Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.0.4-14
 - Remove *.cmt, *.cmti and *.annot
 

--- a/SPECS/ocaml-camlp4.spec
+++ b/SPECS/ocaml-camlp4.spec
@@ -7,7 +7,7 @@
 
 Name:          ocaml-camlp4
 Version:       4.02.2
-Release:       0.2.git%{shortcommit}%{?dist}
+Release:       0.3.git%{shortcommit}%{?dist}
 
 Summary:       Pre-Processor-Pretty-Printer for OCaml
 
@@ -94,6 +94,9 @@ make install \
 %dir %{_libdir}/ocaml/camlp4/Camlp4Top
 %{_libdir}/ocaml/camlp4/Camlp4Top/*.cmi
 %{_libdir}/ocaml/camlp4/Camlp4Top/*.cmo
+%exclude %{_libdir}/ocaml/camlp4/*.annot
+%exclude %{_libdir}/ocaml/camlp4/*.cmt
+%exclude %{_libdir}/ocaml/camlp4/*.cmti
 
 
 %files devel
@@ -117,6 +120,9 @@ make install \
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 4.02.2-0.3.git1e8965ea
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed Jun 24 2015 Richard W.M. Jones <rjones@redhat.com> - 4.02.2-0.2.git1e8965ea
 - ocaml-4.02.2 final rebuild.
 

--- a/SPECS/ocaml-cmdliner.spec
+++ b/SPECS/ocaml-cmdliner.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-cmdliner
 Version:        0.9.5
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Declarative definition of commandline interfaces for OCaml
 License:        BSD3
 URL:            http://erratique.ch/software/cmdliner
@@ -46,6 +46,9 @@ cp _build/src/cmdliner.a _build/src/cmdliner.cma _build/src/cmdliner.cmi _build/
 %exclude %{_libdir}/ocaml/cmdliner/*.cmxa
 %exclude %{_libdir}/ocaml/cmdliner/*.cmx
 %exclude %{_libdir}/ocaml/cmdliner/*.mli
+%exclude %{_libdir}/ocaml/cmdliner/*.annot
+%exclude %{_libdir}/ocaml/cmdliner/*.cmt
+%exclude %{_libdir}/ocaml/cmdliner/*.cmti
 
 %files devel
 %{_libdir}/ocaml/cmdliner/*.a
@@ -54,6 +57,9 @@ cp _build/src/cmdliner.a _build/src/cmdliner.cma _build/src/cmdliner.cmi _build/
 %{_libdir}/ocaml/cmdliner/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.9.5-3
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Apr 7 2015 Euan Harris <euan.harris@citrix.com> - 0.9.5-2
 - Switch back to GitHub mirror
 

--- a/SPECS/ocaml-comparelib.spec
+++ b/SPECS/ocaml-comparelib.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-comparelib
 Version:        109.60.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Syntax extension that derives comparison functions from type representations.
 
 Group:          Development/Libraries
@@ -81,6 +81,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/comparelib/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/comparelib/*.ml
+%exclude %{_libdir}/ocaml/comparelib/*.annot
+%exclude %{_libdir}/ocaml/comparelib/*.cmt
+%exclude %{_libdir}/ocaml/comparelib/*.cmti
 
 
 %files devel
@@ -94,6 +97,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 109.60.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 109.60.00-1
 - Update to 109.60.00
 

--- a/SPECS/ocaml-conduit.spec
+++ b/SPECS/ocaml-conduit.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-conduit
 Version:        0.8.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml network conduit library
 License:        Unknown 
 Group:          Development/Libraries
@@ -57,6 +57,9 @@ make install
 %exclude %{_libdir}/ocaml/conduit/*.a
 %exclude %{_libdir}/ocaml/conduit/*.cmxa
 %exclude %{_libdir}/ocaml/conduit/*.cmx
+%exclude %{_libdir}/ocaml/conduit/*.annot
+%exclude %{_libdir}/ocaml/conduit/*.cmt
+%exclude %{_libdir}/ocaml/conduit/*.cmti
 
 
 %files devel
@@ -65,6 +68,9 @@ make install
 %{_libdir}/ocaml/conduit/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.8.2-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Apr 24 2015 David Scott <dave.scott@citrix.com> - 0.8.2-1
 - Update to 0.8.2
 - Backport fix for Unix domain sockets

--- a/SPECS/ocaml-core-kernel.spec
+++ b/SPECS/ocaml-core-kernel.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-core-kernel
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        System-independent part of Jane Street's Core.
 
 Group:          Development/Libraries
@@ -102,6 +102,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/core_kernel/*.ml
 %exclude %{_libdir}/ocaml/core_kernel/*.mli
+%exclude %{_libdir}/ocaml/core_kernel/*.annot
+%exclude %{_libdir}/ocaml/core_kernel/*.cmt
+%exclude %{_libdir}/ocaml/core_kernel/*.cmti
 %{_libdir}/ocaml/stublibs/*.so
 %{_libdir}/ocaml/stublibs/*.so.owner
 
@@ -116,6 +119,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/core_kernel/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-core.spec
+++ b/SPECS/ocaml-core.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-core
 Version:        112.35.01
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        System-independent part of Jane Street's Core.
 
 Group:          Development/Libraries
@@ -118,6 +118,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/core/*.ml
 %exclude %{_libdir}/ocaml/core/*.mli
+%exclude %{_libdir}/ocaml/core/*.annot
+%exclude %{_libdir}/ocaml/core/*.cmt
+%exclude %{_libdir}/ocaml/core/*.cmti
 %{_libdir}/ocaml/stublibs/*.so
 %{_libdir}/ocaml/stublibs/*.so.owner
 
@@ -132,6 +135,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/core/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.01-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.01-1
 - Update to 112.35.01
 

--- a/SPECS/ocaml-cow.spec
+++ b/SPECS/ocaml-cow.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-cow
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        XML, JSON, HTML, CSS, and Markdown syntax and libraries
 License:        ISC
 URL:            https://github.com/mirage/ocaml-cow
@@ -73,6 +73,9 @@ make install
 %exclude %{_libdir}/ocaml/cow/*.a
 %exclude %{_libdir}/ocaml/cow/*.cmxa
 %exclude %{_libdir}/ocaml/cow/*.mli
+%exclude %{_libdir}/ocaml/cow/*.annot
+%exclude %{_libdir}/ocaml/cow/*.cmt
+%exclude %{_libdir}/ocaml/cow/*.cmti
 
 %files devel
 %{_libdir}/ocaml/cow/*.a
@@ -80,5 +83,8 @@ make install
 %{_libdir}/ocaml/cow/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.0.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Oct 16 2014 David Scott <dave.scott@citrix.com> - 1.0.0-1
 - Initial package

--- a/SPECS/ocaml-cstruct.spec
+++ b/SPECS/ocaml-cstruct.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-cstruct
 Version:        1.4.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Read and write low-level C-style structures in OCaml
 License:        ISC
 URL:            https://github.com/mirage/ocaml-cstruct
@@ -53,6 +53,9 @@ ocaml setup.ml -install DESTDIR=%{buildroot}
 %exclude %{_libdir}/ocaml/cstruct/*.mli
 %{_libdir}/ocaml/stublibs/dllcstruct_stubs.so
 %{_libdir}/ocaml/stublibs/dllcstruct_stubs.so.owner
+%exclude %{_libdir}/ocaml/cstruct/*.annot
+%exclude %{_libdir}/ocaml/cstruct/*.cmt
+%exclude %{_libdir}/ocaml/cstruct/*.cmti
 
 %files devel
 %{_libdir}/ocaml/cstruct/*.a
@@ -61,6 +64,9 @@ ocaml setup.ml -install DESTDIR=%{buildroot}
 %{_libdir}/ocaml/cstruct/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.4.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 28 2014 David Scott <dave.scott@citrix.com> - 1.4.0-1
 - Update to 1.4.0
 

--- a/SPECS/ocaml-ctypes.spec
+++ b/SPECS/ocaml-ctypes.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-ctypes
 Version:        0.4.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Library for binding to C libraries using pure OCaml
 License:        MIT
 URL:            https://github.com/ocamllabs/ocaml-ctypes/
@@ -41,6 +41,9 @@ make install
 %exclude %{_libdir}/ocaml/ctypes/*.cmxa
 %exclude %{_libdir}/ocaml/ctypes/*.cmx
 %exclude %{_libdir}/ocaml/ctypes/*.mli
+%exclude %{_libdir}/ocaml/ctypes/*.annot
+%exclude %{_libdir}/ocaml/ctypes/*.cmt
+%exclude %{_libdir}/ocaml/ctypes/*.cmti
 
 %files devel
 %{_libdir}/ocaml/ctypes/*.a
@@ -49,6 +52,9 @@ make install
 %{_libdir}/ocaml/ctypes/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.4.1-3
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri May  1 2015 Si Beaumont <simon.beaumont@citrix.com> - 0.4.1-2
 - Package shared libaries in the right place
 

--- a/SPECS/ocaml-custom-printf.spec
+++ b/SPECS/ocaml-custom-printf.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-custom-printf
 Version:        111.25.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Syntax extension for printf format strings
 
 Group:          Development/Libraries
@@ -83,6 +83,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/custom_printf/*.ml
 %exclude %{_libdir}/ocaml/custom_printf/*.mli
+%exclude %{_libdir}/ocaml/custom_printf/*.annot
+%exclude %{_libdir}/ocaml/custom_printf/*.cmt
+%exclude %{_libdir}/ocaml/custom_printf/*.cmti
 
 
 %files devel
@@ -97,6 +100,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 111.25.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 111.25.00-1
 - Update to 111.25.00
 

--- a/SPECS/ocaml-dyntype.spec
+++ b/SPECS/ocaml-dyntype.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-dyntype
 Version:        0.9.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        syntax extension which makes OCaml types and values easier to manipulate programmatically
 License:        ISC
 URL:            https://github.com/mirage/dyntype/
@@ -37,11 +37,17 @@ make install
 %{_libdir}/ocaml/dyntype
 %exclude %{_libdir}/ocaml/dyntype/*.a
 %exclude %{_libdir}/ocaml/dyntype/*.cmxa
+%exclude %{_libdir}/ocaml/dyntype/*.annot
+%exclude %{_libdir}/ocaml/dyntype/*.cmt
+%exclude %{_libdir}/ocaml/dyntype/*.cmti
 
 %files devel
 %{_libdir}/ocaml/dyntype/*.a
 %{_libdir}/ocaml/dyntype/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.9.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Oct 16 2014 David Scott <dave.scott@citrix.com> - 0.9.0-1
 - Initial package

--- a/SPECS/ocaml-easy-format.spec
+++ b/SPECS/ocaml-easy-format.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-easy-format
 Version:        1.0.1
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Indentation made easy
 License:        BSD3
 URL:            http://mjambon.com/easy-format.html
@@ -37,12 +37,18 @@ make install
 %{_libdir}/ocaml/easy-format
 %exclude %{_libdir}/ocaml/easy-format/*.cmx
 %exclude %{_libdir}/ocaml/easy-format/*.mli
+%exclude %{_libdir}/ocaml/easy-format/*.annot
+%exclude %{_libdir}/ocaml/easy-format/*.cmt
+%exclude %{_libdir}/ocaml/easy-format/*.cmti
 
 %files devel
 %{_libdir}/ocaml/easy-format/*.cmx
 %{_libdir}/ocaml/easy-format/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.0.1-4
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 21 2014 Euan Harris <euan.harris@citrix.com> - 1.0.1-3
 - Switch to GitHub sources
 

--- a/SPECS/ocaml-enumerate.spec
+++ b/SPECS/ocaml-enumerate.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-enumerate
 Version:        111.08.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Quotation expanders for enumerating finite types.
 
 Group:          Development/Libraries
@@ -55,6 +55,9 @@ make install
 %exclude %{_libdir}/ocaml/enumerate/*.cmxa
 %exclude %{_libdir}/ocaml/enumerate/*.cmx
 %exclude %{_libdir}/ocaml/enumerate/*.mli
+%exclude %{_libdir}/ocaml/enumerate/*.annot
+%exclude %{_libdir}/ocaml/enumerate/*.cmt
+%exclude %{_libdir}/ocaml/enumerate/*.cmti
 
 %files devel
 %{_libdir}/ocaml/enumerate/*.a
@@ -63,6 +66,9 @@ make install
 %{_libdir}/ocaml/enumerate/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 111.08.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 111.08.00-1
 - Initial package
 

--- a/SPECS/ocaml-ezjsonm.spec
+++ b/SPECS/ocaml-ezjsonm.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-ezjsonm
 Version:        0.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        An easy interface on top of the Jsonm library
 License:        ISC
 URL:            https://github.com/samoht/ezjsonm
@@ -45,6 +45,9 @@ make install
 %exclude %{_libdir}/ocaml/ezjsonm/*.cmxa
 %exclude %{_libdir}/ocaml/ezjsonm/*.cmx
 %exclude %{_libdir}/ocaml/ezjsonm/*.mli
+%exclude %{_libdir}/ocaml/ezjsonm/*.annot
+%exclude %{_libdir}/ocaml/ezjsonm/*.cmt
+%exclude %{_libdir}/ocaml/ezjsonm/*.cmti
 
 %files devel
 %{_libdir}/ocaml/ezjsonm/*.a
@@ -53,5 +56,8 @@ make install
 %{_libdir}/ocaml/ezjsonm/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.2.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Oct 16 2014 David Scott <dave.scott@citrix.com> - 0.2.0-1
 - Initial package

--- a/SPECS/ocaml-fieldslib.spec
+++ b/SPECS/ocaml-fieldslib.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-fieldslib
 Version:        109.20.03
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml record fields as first class values
 
 Group:          Development/Libraries
@@ -54,6 +54,9 @@ make install
 %exclude %{_libdir}/ocaml/fieldslib/*.cmxa
 %exclude %{_libdir}/ocaml/fieldslib/*.cmx
 %exclude %{_libdir}/ocaml/fieldslib/*.mli
+%exclude %{_libdir}/ocaml/fieldslib/*.annot
+%exclude %{_libdir}/ocaml/fieldslib/*.cmt
+%exclude %{_libdir}/ocaml/fieldslib/*.cmti
 
 %files devel
 %{_libdir}/ocaml/fieldslib/*.a
@@ -62,6 +65,9 @@ make install
 %{_libdir}/ocaml/fieldslib/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 109.20.03-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue May 6 2014 Jon Ludlam <jonathan.ludlam@citrix.com> - 109.20.00-1
 - Initial package
 

--- a/SPECS/ocaml-fileutils.spec
+++ b/SPECS/ocaml-fileutils.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-fileutils
 Version:        0.4.4
-Release:        6%{?dist}
+Release:        7%{?dist}
 Summary:        OCaml library for common file and filename operations
 
 License:        LGPLv2 with exceptions
@@ -82,6 +82,9 @@ make test
 %endif
 %exclude %{_libdir}/ocaml/fileutils/*.ml
 %exclude %{_libdir}/ocaml/fileutils/*.mli
+%exclude %{_libdir}/ocaml/fileutils/*.annot
+%exclude %{_libdir}/ocaml/fileutils/*.cmt
+%exclude %{_libdir}/ocaml/fileutils/*.cmti
 
 
 %files devel
@@ -96,6 +99,9 @@ make test
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.4.4-7
+- Remove *.cmt, *.cmti and *.annot
+
 * Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 0.4.4-6
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
 

--- a/SPECS/ocaml-findlib.spec
+++ b/SPECS/ocaml-findlib.spec
@@ -6,7 +6,7 @@
 
 Name:           ocaml-findlib
 Version:        1.5.5
-Release:        1%{?extrarelease}
+Release:        2%{?extrarelease}
 Summary:        Objective CAML package manager and build helper
 
 Group:          Development/Libraries
@@ -104,6 +104,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/findlib/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/findlib/*.mli
+%exclude %{_libdir}/ocaml/findlib/*.annot
+%exclude %{_libdir}/ocaml/findlib/*.cmt
+%exclude %{_libdir}/ocaml/findlib/*.cmti
 %exclude %{_libdir}/ocaml/findlib/Makefile.config
 %{_libdir}/ocaml/num-top
 %if !%opt
@@ -123,6 +126,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.5.5-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Apr  3 2015 David Scott <dave.scott@citrix.com>
 - Update to 1.5.5 with bytes package
 

--- a/SPECS/ocaml-flock.spec
+++ b/SPECS/ocaml-flock.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-flock
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml bindings to flock(2)
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/simonjbeaumont/ocaml-flock
@@ -52,8 +52,14 @@ make test
 %exclude %{_libdir}/ocaml/flock/*.a
 %exclude %{_libdir}/ocaml/flock/*.cmxa
 %exclude %{_libdir}/ocaml/flock/*.mli
+%exclude %{_libdir}/ocaml/flock/*.annot
+%exclude %{_libdir}/ocaml/flock/*.cmt
+%exclude %{_libdir}/ocaml/flock/*.cmti
 %exclude %{_libdir}/ocaml/flock_bindings/*.a
 %exclude %{_libdir}/ocaml/flock_bindings/*.cmxa
+%exclude %{_libdir}/ocaml/flock_bindings/*.annot
+%exclude %{_libdir}/ocaml/flock_bindings/*.cmt
+%exclude %{_libdir}/ocaml/flock_bindings/*.cmti
 
 %files devel
 %{_libdir}/ocaml/flock/*.a
@@ -63,5 +69,8 @@ make test
 %{_libdir}/ocaml/flock_bindings/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.0.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Mon Nov 9 2015 Si Beaumont <simon.beaumont@citrix.com> - 1.0.0-1
 - Initial package

--- a/SPECS/ocaml-getopt.spec
+++ b/SPECS/ocaml-getopt.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-getopt
 Version:        20040811
-Release:        1%{?extrarelease}
+Release:        2%{?extrarelease}
 Summary:        Command line parsing a la GNU getopt
 License:        MIT-like
 Group:          Development/Other
@@ -57,6 +57,9 @@ rm -rf %{buildroot}
 %{_libdir}/ocaml/getopt/META
 %{_libdir}/ocaml/getopt/*.cma
 %{_libdir}/ocaml/getopt/*.cmi
+%exclude %{_libdir}/ocaml/getopt/META/*.annot
+%exclude %{_libdir}/ocaml/getopt/META/*.cmt
+%exclude %{_libdir}/ocaml/getopt/META/*.cmti
 
 %files devel
 %defattr(-,root,root)
@@ -70,6 +73,9 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 20040811-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri May 14 2010 David Scott <dave.scott@eu.citrix.com>
 - Customise for XCP
 

--- a/SPECS/ocaml-herelib.spec
+++ b/SPECS/ocaml-herelib.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-herelib
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Syntax extension for inserting the current location.
 
 Group:          Development/Libraries
@@ -82,6 +82,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/herelib/*.ml
 %exclude %{_libdir}/ocaml/herelib/*.mli
+%exclude %{_libdir}/ocaml/herelib/*.annot
+%exclude %{_libdir}/ocaml/herelib/*.cmt
+%exclude %{_libdir}/ocaml/herelib/*.cmti
 
 
 %files devel
@@ -96,6 +99,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-inotify.spec
+++ b/SPECS/ocaml-inotify.spec
@@ -64,6 +64,9 @@ chrpath --delete $OCAMLFIND_DESTDIR/stublibs/dll*.so
 %exclude %{_libdir}/ocaml/inotify/*.a
 %exclude %{_libdir}/ocaml/inotify/*.cmxa
 %exclude %{_libdir}/ocaml/inotify/*.mli
+%exclude %{_libdir}/ocaml/inotify/*.annot
+%exclude %{_libdir}/ocaml/inotify/*.cmt
+%exclude %{_libdir}/ocaml/inotify/*.cmti
 %{_libdir}/ocaml/stublibs/*.so
 %{_libdir}/ocaml/stublibs/*.so.owner
 
@@ -77,6 +80,9 @@ chrpath --delete $OCAMLFIND_DESTDIR/stublibs/dll*.so
 %changelog
 * Thu Aug 25 2016 Christian Lindig <christian.lindig@citrix.com> - 2.3-1
 - Packaged new upstream release
+
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.0-2
+- Remove *.cmt, *.cmti and *.annot
 
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 2.0-1
 - Update to 2.0

--- a/SPECS/ocaml-inotify.spec
+++ b/SPECS/ocaml-inotify.spec
@@ -6,7 +6,7 @@ Summary:        Inotify bindings for OCaml.
 Group:          Development/Libraries
 License:        LGPLv2 with exceptions
 URL:            https://github.com/whitequark/ocaml-inotify
-Source0:        https://github.com/whitequark/ocaml-inotify/archive/%{version}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/whitequark/ocaml-inotify/archive/v%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires:  ocaml >= 4.02.2
 BuildRequires:  ocaml-ocamldoc

--- a/SPECS/ocaml-io-page.spec
+++ b/SPECS/ocaml-io-page.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-io-page
 Version:        1.1.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Efficient handling of I/O memory pages on Unix and Xen.
 License:        ISC
 URL:            https://github.com/mirage/io-page
@@ -47,6 +47,9 @@ make install
 %exclude %{_libdir}/ocaml/io-page/*.cmxa
 %exclude %{_libdir}/ocaml/io-page/*.cmx
 %exclude %{_libdir}/ocaml/io-page/*.mli
+%exclude %{_libdir}/ocaml/io-page/*.annot
+%exclude %{_libdir}/ocaml/io-page/*.cmt
+%exclude %{_libdir}/ocaml/io-page/*.cmti
 
 %files devel
 %{_libdir}/ocaml/io-page/*.a
@@ -55,6 +58,9 @@ make install
 %{_libdir}/ocaml/io-page/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.1.1-3
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri May 30 2014 Euan Harris <euan.harris@citrix.com> - 1.1.1-2
 - Split files corrrectly between base and devel packages
 

--- a/SPECS/ocaml-ipaddr.spec
+++ b/SPECS/ocaml-ipaddr.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-ipaddr
 Version:        2.5.0
-Release:        1000%{?dist}
+Release:        1001%{?dist}
 Summary:        Pure OCaml parsers and printers for IP addresses
 License:        ISC
 URL:            https://github.com/mirage/ocaml-ipaddr
@@ -43,6 +43,9 @@ make install
 %exclude %{_libdir}/ocaml/ipaddr/*.cmx
 %exclude %{_libdir}/ocaml/ipaddr/*.ml
 %exclude %{_libdir}/ocaml/ipaddr/*.mli
+%exclude %{_libdir}/ocaml/ipaddr/*.annot
+%exclude %{_libdir}/ocaml/ipaddr/*.cmt
+%exclude %{_libdir}/ocaml/ipaddr/*.cmti
 
 %files devel
 %{_libdir}/ocaml/ipaddr/*.a
@@ -51,6 +54,9 @@ make install
 %{_libdir}/ocaml/ipaddr/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.5.0-1001
+- Remove *.cmt, *.cmti and *.annot
+
 * Sat Jul 19 2014 David Scott <dave.scott@citrix.com> - 2.5.0-1000
 - Update to 2.5.0; override upstream package
 

--- a/SPECS/ocaml-jsonm.spec
+++ b/SPECS/ocaml-jsonm.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-jsonm
 Version:        0.9.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Non-blocking streaming JSON codec for OCaml
 License:        BSD3
 URL:            http://erratique.ch/software/jsonm
@@ -65,6 +65,9 @@ ocaml setup.ml -install
 %exclude %{_libdir}/ocaml/jsonm/*.cmxa
 %exclude %{_libdir}/ocaml/jsonm/*.cmx
 %exclude %{_libdir}/ocaml/jsonm/*.mli
+%exclude %{_libdir}/ocaml/jsonm/*.annot
+%exclude %{_libdir}/ocaml/jsonm/*.cmt
+%exclude %{_libdir}/ocaml/jsonm/*.cmti
 %{_bindir}/jsontrip
 %{_bindir}/ocamltweets
 
@@ -75,5 +78,8 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/jsonm/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.9.1-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Oct 16 2014 David Scott <dave.scott@citri.com> - 0.9.1-1
 - Initial package

--- a/SPECS/ocaml-kaputt.spec
+++ b/SPECS/ocaml-kaputt.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-kaputt
 Version:        1.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml testing tool
 License:        GPL
 URL:            http://kaputt.x9c.fr/
@@ -42,6 +42,9 @@ make install
 %exclude %{_libdir}/ocaml/kaputt/*.a
 %exclude %{_libdir}/ocaml/kaputt/*.cmxa
 %exclude %{_libdir}/ocaml/kaputt/*.cmx
+%exclude %{_libdir}/ocaml/kaputt/*.annot
+%exclude %{_libdir}/ocaml/kaputt/*.cmt
+%exclude %{_libdir}/ocaml/kaputt/*.cmti
 
 %files devel
 %{_libdir}/ocaml/kaputt/*.a
@@ -49,6 +52,9 @@ make install
 %{_libdir}/ocaml/kaputt/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Sun Apr 12 2015 Jon Ludlam <jonathan.ludlam@citrix.com> - 1.2-1
 - Initial package
 

--- a/SPECS/ocaml-lwt.spec
+++ b/SPECS/ocaml-lwt.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-lwt
 Version:        2.4.8
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml lightweight thread library
 
 License:        LGPLv2+ with exceptions
@@ -73,10 +73,16 @@ strip $OCAMLFIND_DESTDIR/stublibs/dll*.so
 %files devel
 %doc LICENSE COPYING CHANGES README.md
 %{_libdir}/ocaml/lwt/*
+%exclude %{_libdir}/ocaml/lwt/*.annot
+%exclude %{_libdir}/ocaml/lwt/*.cmt
+%exclude %{_libdir}/ocaml/lwt/*.cmti
 %{_libdir}/ocaml/stublibs/*.so
 %{_libdir}/ocaml/stublibs/*.so.owner
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.4.8-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Sun May 11 2014 David Scott <dave.scott@citrix.com> - 2.4.5-1
 - Update to 2.4.5
 

--- a/SPECS/ocaml-mirage-block-unix.spec
+++ b/SPECS/ocaml-mirage-block-unix.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-mirage-block-unix
 Version:        1.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Mirage block driver for Unix that implements the blkfront/back protocol
 License:        ISC
 URL:            https://github.com/mirage/mirage-block-unix/
@@ -49,6 +49,9 @@ make install
 %exclude %{_libdir}/ocaml/mirage-block-unix/*.cmxa
 %exclude %{_libdir}/ocaml/mirage-block-unix/*.cmx
 %exclude %{_libdir}/ocaml/mirage-block-unix/*.mli
+%exclude %{_libdir}/ocaml/mirage-block-unix/*.annot
+%exclude %{_libdir}/ocaml/mirage-block-unix/*.cmt
+%exclude %{_libdir}/ocaml/mirage-block-unix/*.cmti
 
 %files devel
 %{_libdir}/ocaml/mirage-block-unix/*.a
@@ -57,5 +60,8 @@ make install
 %{_libdir}/ocaml/mirage-block-unix/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2.2-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Sun Apr 12 2015 Jon Ludlam <jonathan.ludlam@citrix.com> - 1.2.1-1
 - Initial package

--- a/SPECS/ocaml-mirage-clock-unix.spec
+++ b/SPECS/ocaml-mirage-clock-unix.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-mirage-clock-unix
 Version:        1.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Mirage-compatible Clock library for Unix
 License:        ISC
 URL:            https://github.com/mirage/mirage-clock/
@@ -42,6 +42,9 @@ make unix-install
 %exclude %{_libdir}/ocaml/mirage-clock-unix/*.a
 %exclude %{_libdir}/ocaml/mirage-clock-unix/*.cmxa
 %exclude %{_libdir}/ocaml/mirage-clock-unix/*.cmx
+%exclude %{_libdir}/ocaml/mirage-clock-unix/*.annot
+%exclude %{_libdir}/ocaml/mirage-clock-unix/*.cmt
+%exclude %{_libdir}/ocaml/mirage-clock-unix/*.cmti
 
 %files devel
 %{_libdir}/ocaml/mirage-clock-unix/*.a
@@ -49,5 +52,8 @@ make unix-install
 %{_libdir}/ocaml/mirage-clock-unix/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.0.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed Jul 16 2014 David Scott <dave.scott@citrix.com> - 1.0.0-1
 - Initial package

--- a/SPECS/ocaml-mirage-types.spec
+++ b/SPECS/ocaml-mirage-types.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-mirage-types
 Version:        1.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        MirageOS interfaces
 License:        ISC
 URL:            https://github.com/mirage/mirage
@@ -45,11 +45,17 @@ make install-types
 %files
 %{_libdir}/ocaml/mirage-types
 %exclude %{_libdir}/ocaml/mirage-types/*.mli
+%exclude %{_libdir}/ocaml/mirage-types/*.annot
+%exclude %{_libdir}/ocaml/mirage-types/*.cmt
+%exclude %{_libdir}/ocaml/mirage-types/*.cmti
 
 %files devel
 %{_libdir}/ocaml/mirage-types/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed Jul 16 2014 David Scott <dave.scott@citrix.com> - 1.2.0-1
 - Update to 1.2.0
 

--- a/SPECS/ocaml-mtime.spec
+++ b/SPECS/ocaml-mtime.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-mtime
 Version:        0.8.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Monotonic wall-clock time for OCaml
 License:        BSD3
 URL:            http://erratique.ch/software/mtime
@@ -63,10 +63,16 @@ cp _build/src-os/mtime_top.cmxs %{buildroot}/%{_libdir}/ocaml/mtime/os
 %doc _build/README.md
 %{_libdir}/ocaml/mtime
 %{_libdir}/ocaml/mtime/os
+%exclude %{_libdir}/ocaml/mtime/*.annot
+%exclude %{_libdir}/ocaml/mtime/*.cmt
+%exclude %{_libdir}/ocaml/mtime/*.cmti
 %exclude %{_libdir}/ocaml/mtime/os/*.a
 %exclude %{_libdir}/ocaml/mtime/os/*.cmxa
 %exclude %{_libdir}/ocaml/mtime/os/*.cmx
 %exclude %{_libdir}/ocaml/mtime/os/*.mli
+%exclude %{_libdir}/ocaml/mtime/os/*.annot
+%exclude %{_libdir}/ocaml/mtime/os/*.cmt
+%exclude %{_libdir}/ocaml/mtime/os/*.cmti
 
 %files devel
 %{_libdir}/ocaml/mtime/os/*.a
@@ -75,5 +81,8 @@ cp _build/src-os/mtime_top.cmxs %{buildroot}/%{_libdir}/ocaml/mtime/os
 %{_libdir}/ocaml/mtime/os/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.8.1-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Apr 24 2015 David Scott <dave.scott@citrix.com> - 0.8.1-1
 - Initial package

--- a/SPECS/ocaml-oclock.spec
+++ b/SPECS/ocaml-oclock.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-oclock
 Version:        0.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        POSIX monotonic clock for OCaml
 License:        ISC
 URL:            https://github.com/polazarus/oclock
@@ -44,6 +44,9 @@ make install DESTDIR=%{buildroot}/%{_libdir}/ocaml
 %{_libdir}/ocaml/oclock
 %exclude %{_libdir}/ocaml/oclock/*.a
 %exclude %{_libdir}/ocaml/oclock/*.cmxa
+%exclude %{_libdir}/ocaml/oclock/*.annot
+%exclude %{_libdir}/ocaml/oclock/*.cmt
+%exclude %{_libdir}/ocaml/oclock/*.cmti
 %{_libdir}/ocaml/stublibs/dlloclock.so
 %{_libdir}/ocaml/stublibs/dlloclock.so.owner
 
@@ -52,6 +55,9 @@ make install DESTDIR=%{buildroot}/%{_libdir}/ocaml
 %{_libdir}/ocaml/oclock/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.3-4
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri May 30 2014 Euan Harris <euan.harris@citrix.com> - 0.3-3
 - Split files correctly between base and devel packages
 

--- a/SPECS/ocaml-ocplib-endian.spec
+++ b/SPECS/ocaml-ocplib-endian.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-ocplib-endian
 Version:        0.4
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Optimized functions to read and write int16/32/64 from strings and bigarrays
 License:        LGPL
 URL:            https://github.com/OCamlPro/ocplib-endian
@@ -55,6 +55,9 @@ ocaml setup.ml -install
 %exclude %{_libdir}/ocaml/ocplib-endian/*.cmxa
 %exclude %{_libdir}/ocaml/ocplib-endian/*.cmx
 %exclude %{_libdir}/ocaml/ocplib-endian/*.mli
+%exclude %{_libdir}/ocaml/ocplib-endian/*.annot
+%exclude %{_libdir}/ocaml/ocplib-endian/*.cmt
+%exclude %{_libdir}/ocaml/ocplib-endian/*.cmti
 
 %files devel
 %{_libdir}/ocaml/ocplib-endian/*.a
@@ -63,6 +66,9 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/ocplib-endian/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.4-3
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri May 30 2014 Euan Harris <euan.harris@citrix.com> - 0.4-2
 - Split files correctly between base and devel packages
 

--- a/SPECS/ocaml-odn.spec
+++ b/SPECS/ocaml-odn.spec
@@ -1,6 +1,6 @@
 Name:		ocaml-odn
 Version:	0.0.11
-Release:	1%{?dist}
+Release:	2%{?dist}
 Summary:	Dump OCaml data structures using OCaml data notation
 
 License:	LGPL
@@ -47,6 +47,9 @@ make install
 %exclude %{_libdir}/ocaml/odn/*.a
 %exclude %{_libdir}/ocaml/odn/*.cmxa
 %exclude %{_libdir}/ocaml/odn/*.cmx
+%exclude %{_libdir}/ocaml/odn/*.annot
+%exclude %{_libdir}/ocaml/odn/*.cmt
+%exclude %{_libdir}/ocaml/odn/*.cmti
 
 %files devel
 %{_libdir}/ocaml/odn/*.a
@@ -54,6 +57,9 @@ make install
 %{_libdir}/ocaml/odn/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.0.11-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Mar 25 2014 Euan Harris <euan.harris@citrix.com> - 0.0.11-1
 - Initial package
 

--- a/SPECS/ocaml-omd.spec
+++ b/SPECS/ocaml-omd.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-omd
 Version:        1.0.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A Markdown frontend in pure OCaml.
 License:        ISC
 URL:            https://github.com/ocaml/omd
@@ -57,6 +57,9 @@ make install
 %exclude %{_libdir}/ocaml/omd/*.cmxa
 %exclude %{_libdir}/ocaml/omd/*.cmx
 %exclude %{_libdir}/ocaml/omd/*.mli
+%exclude %{_libdir}/ocaml/omd/*.annot
+%exclude %{_libdir}/ocaml/omd/*.cmt
+%exclude %{_libdir}/ocaml/omd/*.cmti
 %{_bindir}/omd
 %{_bindir}/test_cow
 %{_bindir}/test_spec
@@ -68,5 +71,8 @@ make install
 %{_libdir}/ocaml/omd/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.0.2-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Oct 16 2014 David Scott <dave.scott@citrix.com> - 1.0.2-1
 - Initial package

--- a/SPECS/ocaml-ounit.spec
+++ b/SPECS/ocaml-ounit.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-ounit
 Version:        2.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Unit test framework for OCaml
 
 License:        MIT
@@ -57,6 +57,9 @@ rm -rf $RPM_BUILD_ROOT/usr/local/share/doc
 %exclude %{_libdir}/ocaml/oUnit/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/oUnit/*.mli
+%exclude %{_libdir}/ocaml/oUnit/*.annot
+%exclude %{_libdir}/ocaml/oUnit/*.cmt
+%exclude %{_libdir}/ocaml/oUnit/*.cmti
 
 %files devel
 %doc LICENSE.txt README.txt
@@ -68,6 +71,9 @@ rm -rf $RPM_BUILD_ROOT/usr/local/share/doc
 %{_libdir}/ocaml/oUnit/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.0.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Mar 25 2014 Euan Harris <euan.harris@citrix.com> - 2.0.0-1
 - Update to version 2.0.0
 

--- a/SPECS/ocaml-pa-bench.spec
+++ b/SPECS/ocaml-pa-bench.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-pa-bench
 Version:        112.06.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Syntax extension for inline benchmarks.
 
 Group:          Development/Libraries
@@ -81,6 +81,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/pa_bench/*.ml
 %exclude %{_libdir}/ocaml/pa_bench/*.mli
+%exclude %{_libdir}/ocaml/pa_bench/*.annot
+%exclude %{_libdir}/ocaml/pa_bench/*.cmt
+%exclude %{_libdir}/ocaml/pa_bench/*.cmti
 
 
 %files devel
@@ -95,6 +98,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.06.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 111.28.00-1
 - Update to 111.28.00
 

--- a/SPECS/ocaml-pa-ounit.spec
+++ b/SPECS/ocaml-pa-ounit.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-pa-ounit
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Syntax extension for in-line tests in code.
 
 Group:          Development/Libraries
@@ -80,6 +80,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/pa_ounit/*.ml
 %exclude %{_libdir}/ocaml/pa_ounit/*.mli
+%exclude %{_libdir}/ocaml/pa_ounit/*.annot
+%exclude %{_libdir}/ocaml/pa_ounit/*.cmt
+%exclude %{_libdir}/ocaml/pa_ounit/*.cmti
 
 
 %files devel
@@ -94,6 +97,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-pa-pipebang.spec
+++ b/SPECS/ocaml-pa-pipebang.spec
@@ -5,7 +5,7 @@
 
 Name:           ocaml-pa-pipebang
 Version:        110.01.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Syntax extension to transform x |! f into f x
 
 Group:          Development/Libraries
@@ -83,6 +83,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/pa_pipebang/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/pa_pipebang/*.ml
+%exclude %{_libdir}/ocaml/pa_pipebang/*.annot
+%exclude %{_libdir}/ocaml/pa_pipebang/*.cmt
+%exclude %{_libdir}/ocaml/pa_pipebang/*.cmti
 
 
 %files devel
@@ -96,6 +99,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 110.01.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 14 2014 David Scott <dave.scott@citrix.com> - 110.01.00-1
 - Update to 110.01.00
 

--- a/SPECS/ocaml-pa-structural-sexp.spec
+++ b/SPECS/ocaml-pa-structural-sexp.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-pa-structural-sexp
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jane Street's pa_structural_sexp
 
 Group:          Development/Libraries
@@ -82,6 +82,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/pa_structural_sexp/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/pa_structural_sexp/*.mli
+%exclude %{_libdir}/ocaml/pa_structural_sexp/*.annot
+%exclude %{_libdir}/ocaml/pa_structural_sexp/*.cmt
+%exclude %{_libdir}/ocaml/pa_structural_sexp/*.cmti
 
 
 %files devel
@@ -94,5 +97,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/pa_structural_sexp/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Nov 12 2015 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Initial package

--- a/SPECS/ocaml-pa-test.spec
+++ b/SPECS/ocaml-pa-test.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-pa-test
 Version:        112.24.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Jane Street's pa_test
 
 Group:          Development/Libraries
@@ -83,6 +83,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/pa_test/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/pa_test/*.mli
+%exclude %{_libdir}/ocaml/pa_test/*.annot
+%exclude %{_libdir}/ocaml/pa_test/*.cmt
+%exclude %{_libdir}/ocaml/pa_test/*.cmti
 
 
 %files devel
@@ -95,6 +98,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/pa_test/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.24.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.24.00-1
 - Update to 112.24.00
 

--- a/SPECS/ocaml-pci.spec
+++ b/SPECS/ocaml-pci.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-pci
 Version:        0.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml bindings to libpci
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/simonjbeaumont/ocaml-pci
@@ -52,8 +52,14 @@ make test
 %exclude %{_libdir}/ocaml/pci/*.a
 %exclude %{_libdir}/ocaml/pci/*.cmxa
 %exclude %{_libdir}/ocaml/pci/*.mli
+%exclude %{_libdir}/ocaml/pci/*.annot
+%exclude %{_libdir}/ocaml/pci/*.cmt
+%exclude %{_libdir}/ocaml/pci/*.cmti
 %exclude %{_libdir}/ocaml/pci_bindings/*.a
 %exclude %{_libdir}/ocaml/pci_bindings/*.cmxa
+%exclude %{_libdir}/ocaml/pci_bindings/*.annot
+%exclude %{_libdir}/ocaml/pci_bindings/*.cmt
+%exclude %{_libdir}/ocaml/pci_bindings/*.cmti
 
 %files devel
 %{_libdir}/ocaml/pci/*.a
@@ -63,6 +69,9 @@ make test
 %{_libdir}/ocaml/pci_bindings/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.2.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed May 20 2015 Si Beaumont <simon.beaumont@citrix.com> - 0.2.0-1
 - Update to 0.2.0
 

--- a/SPECS/ocaml-ppxtools.spec
+++ b/SPECS/ocaml-ppxtools.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-ppxtools
 Version:        5.0+4.02.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A tool for code coverage profiling
 License:        MIT
 URL:            https://github.com/alainfrisch/ppx_tools
@@ -41,6 +41,9 @@ make install
 %exclude %{_libdir}/ocaml/ppx_tools/*.cmxa
 %exclude %{_libdir}/ocaml/ppx_tools/*.cmx
 %exclude %{_libdir}/ocaml/ppx_tools/*.mli
+%exclude %{_libdir}/ocaml/ppx_tools/*.annot
+%exclude %{_libdir}/ocaml/ppx_tools/*.cmt
+%exclude %{_libdir}/ocaml/ppx_tools/*.cmti
 
 %files devel
 %{_libdir}/ocaml/ppx_tools/*.a
@@ -49,6 +52,9 @@ make install
 %{_libdir}/ocaml/ppx_tools/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 5.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed May 11 2016 Christian Lindig <christian.lindig@citrix.com> - 5.0+4.02.0-1
 - Initial package
 

--- a/SPECS/ocaml-re.spec
+++ b/SPECS/ocaml-re.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-re
 Version:        1.2.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A regular expression library for OCaml
 License:        LGPL
 URL:            https://github.com/ocaml/ocaml-re
@@ -43,6 +43,9 @@ make install
 %exclude %{_libdir}/ocaml/re/*.cmxa
 %exclude %{_libdir}/ocaml/re/*.cmx
 %exclude %{_libdir}/ocaml/re/*.mli
+%exclude %{_libdir}/ocaml/re/*.annot
+%exclude %{_libdir}/ocaml/re/*.cmt
+%exclude %{_libdir}/ocaml/re/*.cmti
 
 %files devel
 %doc re-api.docdir/*
@@ -53,6 +56,9 @@ make install
 %{_libdir}/ocaml/re/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2.2-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Sat Jun  7 2014 David Scott <dave.scott@citrix.com> - 1.2.2-1
 - Update to 1.2.2
 

--- a/SPECS/ocaml-react.spec
+++ b/SPECS/ocaml-react.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-react
 Version:        1.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        OCaml framework for Functional Reactive Programming (FRP)
 License:        BSD
 URL:            http://erratique.ch/software/react
@@ -53,6 +53,9 @@ cp _build/pkg/META _build/src/react.a _build/src/react.cma _build/src/react.cmi 
 %exclude %{_libdir}/ocaml/react/*.cmxa
 %exclude %{_libdir}/ocaml/react/*.cmx
 %exclude %{_libdir}/ocaml/react/*.mli
+%exclude %{_libdir}/ocaml/react/*.annot
+%exclude %{_libdir}/ocaml/react/*.cmt
+%exclude %{_libdir}/ocaml/react/*.cmti
 
 %files devel
 %{_libdir}/ocaml/react/*.a
@@ -61,6 +64,9 @@ cp _build/pkg/META _build/src/react.a _build/src/react.cma _build/src/react.cmi 
 %{_libdir}/ocaml/react/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.1.0-3
+- Remove *.cmt, *.cmti and *.annot
+
 * Sat Jun  7 2014 David Scott <dave.scott@citrix.com> - 1.1.0-2
 - Update for 1.1.0
 

--- a/SPECS/ocaml-rpc.spec
+++ b/SPECS/ocaml-rpc.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-rpc
 Version:        1.5.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        An RPC library for OCaml
 License:        LGPL
 URL:            https://github.com/mirage/ocaml-rpc
@@ -45,11 +45,17 @@ make install DESTDIR=${buildroot}
 %doc README.md
 %{_libdir}/ocaml/rpclib
 %exclude %{_libdir}/ocaml/rpclib/*.cmx
+%exclude %{_libdir}/ocaml/rpclib/*.annot
+%exclude %{_libdir}/ocaml/rpclib/*.cmt
+%exclude %{_libdir}/ocaml/rpclib/*.cmti
 
 %files devel
 %{_libdir}/ocaml/rpclib/*.cmx
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.5.5-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Jul 23 2015 Jon Ludlam <jonathan.ludlam@citrix.com> - 1.5.5-1
 - Update to 1.5.5
 

--- a/SPECS/ocaml-sexplib.spec
+++ b/SPECS/ocaml-sexplib.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-sexplib
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Convert values to and from s-expressions in OCaml
 
 License:        LGPLv2+ with exceptions and BSD
@@ -54,15 +54,24 @@ make install
 %exclude %{_libdir}/ocaml/sexplib/*.cmxa
 %exclude %{_libdir}/ocaml/sexplib/*.cmx
 %exclude %{_libdir}/ocaml/sexplib/*.mli
+%exclude %{_libdir}/ocaml/sexplib/*.annot
+%exclude %{_libdir}/ocaml/sexplib/*.cmt
+%exclude %{_libdir}/ocaml/sexplib/*.cmti
 %{_libdir}/ocaml/sexplib_num
 %exclude %{_libdir}/ocaml/sexplib_num/*.a
 %exclude %{_libdir}/ocaml/sexplib_num/*.cmxa
 %exclude %{_libdir}/ocaml/sexplib_num/*.cmx
 %exclude %{_libdir}/ocaml/sexplib_num/*.mli
+%exclude %{_libdir}/ocaml/sexplib_num/*.annot
+%exclude %{_libdir}/ocaml/sexplib_num/*.cmt
+%exclude %{_libdir}/ocaml/sexplib_num/*.cmti
 %{_libdir}/ocaml/sexplib_unix
 %exclude %{_libdir}/ocaml/sexplib_unix/*.a
 %exclude %{_libdir}/ocaml/sexplib_unix/*.cmxa
 %exclude %{_libdir}/ocaml/sexplib_unix/*.cmx
+%exclude %{_libdir}/ocaml/sexplib_unix/*.annot
+%exclude %{_libdir}/ocaml/sexplib_unix/*.cmt
+%exclude %{_libdir}/ocaml/sexplib_unix/*.cmti
 
 %files devel
 %{_libdir}/ocaml/sexplib/*.a
@@ -78,6 +87,9 @@ make install
 %{_libdir}/ocaml/sexplib_unix/*.cmxa
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-shared-block-ring.spec
+++ b/SPECS/ocaml-shared-block-ring.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-shared-block-ring
 Version:        2.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml implementation of shared block rings
 License:        ISC
 URL:            https://github.com/mirage/shared-block-ring/
@@ -57,6 +57,9 @@ make install
 %exclude %{_libdir}/ocaml/shared-block-ring/*.cmxa
 %exclude %{_libdir}/ocaml/shared-block-ring/*.cmx
 %exclude %{_libdir}/ocaml/shared-block-ring/*.mli
+%exclude %{_libdir}/ocaml/shared-block-ring/*.annot
+%exclude %{_libdir}/ocaml/shared-block-ring/*.cmt
+%exclude %{_libdir}/ocaml/shared-block-ring/*.cmti
 
 %files devel
 %{_libdir}/ocaml/shared-block-ring/*.a
@@ -65,6 +68,9 @@ make install
 %{_libdir}/ocaml/shared-block-ring/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 2.2.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Mon Apr 25 2016 Euan Harris <euan.harris@citrix.com> - 2.2.0-1
 - Update to 2.2.0
 

--- a/SPECS/ocaml-ssl.spec
+++ b/SPECS/ocaml-ssl.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-ssl
 Version:        0.5.2
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Use OpenSSL from OCaml
 License:        LGPL
 URL:            http://downloads.sourceforge.net/project/savonet/ocaml-ssl
@@ -49,6 +49,9 @@ make install DESTDIR=%{buildroot}
 %exclude %{_libdir}/ocaml/ssl/*.cmxa
 %exclude %{_libdir}/ocaml/ssl/*.cmx
 %exclude %{_libdir}/ocaml/ssl/*.mli
+%exclude %{_libdir}/ocaml/ssl/*.annot
+%exclude %{_libdir}/ocaml/ssl/*.cmt
+%exclude %{_libdir}/ocaml/ssl/*.cmti
 %{_libdir}/ocaml/stublibs/dllssl_stubs.so
 %{_libdir}/ocaml/stublibs/dllssl_stubs.so.owner
 %{_libdir}/ocaml/stublibs/dllssl_threads_stubs.so
@@ -61,6 +64,9 @@ make install DESTDIR=%{buildroot}
 %{_libdir}/ocaml/ssl/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.5.2-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue May 24 2016 Phus Lu <phus.lu@citrix.com> - 0.5.2-1
 - Upgrade to ocaml-ssl-0.5.2 for TLSv1.2
 

--- a/SPECS/ocaml-stringext.spec
+++ b/SPECS/ocaml-stringext.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-stringext
 Version:        0.0.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        String manipulation functions
 License:        Unknown 
 Group:          Development/Libraries
@@ -42,6 +42,9 @@ ocaml setup.ml -install
 %exclude %{_libdir}/ocaml/stringext/*.cmxa
 %exclude %{_libdir}/ocaml/stringext/*.cmx
 %exclude %{_libdir}/ocaml/stringext/*.mli
+%exclude %{_libdir}/ocaml/stringext/*.annot
+%exclude %{_libdir}/ocaml/stringext/*.cmt
+%exclude %{_libdir}/ocaml/stringext/*.cmti
 
 
 %files devel
@@ -51,6 +54,9 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/stringext/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.0.1-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri May 2 2014 Jon Ludlam <jonathan.ludlam@citrix.com> - 0.0.1-1
 - Initial package
 

--- a/SPECS/ocaml-tar.spec
+++ b/SPECS/ocaml-tar.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-tar
 Version:        0.2.1
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        OCaml parser and printer for tar-format data
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/mirage/ocaml-tar
@@ -47,6 +47,9 @@ ocaml setup.ml -install
 %exclude %{_libdir}/ocaml/tar/*.cmxa
 %exclude %{_libdir}/ocaml/tar/*.cmx
 %exclude %{_libdir}/ocaml/tar/*.mli
+%exclude %{_libdir}/ocaml/tar/*.annot
+%exclude %{_libdir}/ocaml/tar/*.cmt
+%exclude %{_libdir}/ocaml/tar/*.cmti
 
 %files devel
 %{_libdir}/ocaml/tar/*.a
@@ -55,6 +58,9 @@ ocaml setup.ml -install
 %{_libdir}/ocaml/tar/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.2.1-3
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri May 30 2014 Euan Harris <euan.harris@citrix.com> - 0.2.1-2
 - Split files correctly between base and devel packages
 

--- a/SPECS/ocaml-text.spec
+++ b/SPECS/ocaml-text.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-text
 Version:        0.8
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Library for dealing with unicode text conveniently
 
 License:        BSD
@@ -50,6 +50,9 @@ rm -rf $RPM_BUILD_ROOT/usr/local/share/doc
 %exclude %{_libdir}/ocaml/text/*.cmxa
 %exclude %{_libdir}/ocaml/text/*.cmx
 %exclude %{_libdir}/ocaml/text/*.mli
+%exclude %{_libdir}/ocaml/text/*.annot
+%exclude %{_libdir}/ocaml/text/*.cmt
+%exclude %{_libdir}/ocaml/text/*.cmti
 %{_libdir}/ocaml/stublibs/dllbigarray_stubs.so
 %{_libdir}/ocaml/stublibs/dllbigarray_stubs.so.owner
 %{_libdir}/ocaml/stublibs/dlltext_stubs.so
@@ -63,6 +66,9 @@ rm -rf $RPM_BUILD_ROOT/usr/local/share/doc
 %{_libdir}/ocaml/text/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.8-3
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jonathan Ludlam <jonathan.ludlam@citrix.com> - 0.8-1
 - Update to 0.8
 

--- a/SPECS/ocaml-type-conv.spec
+++ b/SPECS/ocaml-type-conv.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-type-conv
 Version:        111.13.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml base library for type conversion
 
 License:        LGPLv2+ with exceptions and BSD
@@ -39,8 +39,14 @@ make install
 %files
 %doc CHANGES.txt COPYRIGHT.txt INRIA-DISCLAIMER.txt INSTALL.txt LICENSE-Tywith.txt LICENSE.txt README.md THIRD-PARTY.txt
 %{_libdir}/ocaml/type_conv
+%exclude %{_libdir}/ocaml/type_conv/*.annot
+%exclude %{_libdir}/ocaml/type_conv/*.cmt
+%exclude %{_libdir}/ocaml/type_conv/*.cmti
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 111.13.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed Jul 16 2014 David Scott <dave.scott@citrix.com> - 111.13.00-1
 - Updated to 111.13.00 for Mirage compatibility
 

--- a/SPECS/ocaml-typerep.spec
+++ b/SPECS/ocaml-typerep.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-typerep
 Version:        112.35.00
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Runtime types for OCaml.
 
 Group:          Development/Libraries
@@ -84,6 +84,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 %exclude %{_libdir}/ocaml/typerep_lib/*.ml
 %exclude %{_libdir}/ocaml/typerep_lib/*.mli
+%exclude %{_libdir}/ocaml/typerep_lib/*.annot
+%exclude %{_libdir}/ocaml/typerep_lib/*.cmt
+%exclude %{_libdir}/ocaml/typerep_lib/*.cmti
 
 
 %files devel
@@ -97,6 +100,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/ocaml/typerep_lib/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 112.35.00-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jan 22 2016 Jon Ludlam <jonathan.ludlam@citrix.com> - 112.35.00-1
 - Update to 112.35.00
 

--- a/SPECS/ocaml-ulex.spec
+++ b/SPECS/ocaml-ulex.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-ulex
 Version:        1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        lexer generator for Unicode and OCaml
 License:        ISC
 URL:            http://ftp.de.debian.org/debian/pool/main/u/ulex/ulex_1.1.orig.tar.gz
@@ -31,7 +31,13 @@ make install
 %{_libdir}/ocaml/ulex/*.cmxa
 %{_libdir}/ocaml/ulex/*.cmx
 %{_libdir}/ocaml/ulex/*.mli
+%exclude %{_libdir}/ocaml/ulex/*.annot
+%exclude %{_libdir}/ocaml/ulex/*.cmt
+%exclude %{_libdir}/ocaml/ulex/*.cmti
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.1-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Oct 16 2014 David Scott <dave.scott@citrix.com> - 1.1-1
 - Initial package

--- a/SPECS/ocaml-uri.spec
+++ b/SPECS/ocaml-uri.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-uri
 Version:        1.6.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A URI library for OCaml
 License:        ISC
 URL:            https://github.com/mirage/ocaml-uri
@@ -50,6 +50,9 @@ make install
 %exclude %{_libdir}/ocaml/uri/*.cmxa
 %exclude %{_libdir}/ocaml/uri/*.cmx
 %exclude %{_libdir}/ocaml/uri/*.mli
+%exclude %{_libdir}/ocaml/uri/*.annot
+%exclude %{_libdir}/ocaml/uri/*.cmt
+%exclude %{_libdir}/ocaml/uri/*.cmti
 
 %files devel
 %doc uri.docdir/*
@@ -61,6 +64,9 @@ make install
 %{_libdir}/ocaml/uri/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.6.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jun 06 2014 Jon Ludlam <jonathan.ludlam@citrix.com> - 1.6.0-1
 - Update to 1.6.0
 

--- a/SPECS/ocaml-uuidm.spec
+++ b/SPECS/ocaml-uuidm.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-uuidm
 Version:        0.9.5
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Universally Unique IDentifiers (UUIDs) for OCaml
 License:        BSD3
 URL:            http://erratique.ch/software/uuidm
@@ -47,6 +47,9 @@ rm -f %{buildroot}/%{_libdir}/ocaml/usr/local/bin/uuidtrip
 %exclude %{_libdir}/ocaml/uuidm/*.cmxa
 %exclude %{_libdir}/ocaml/uuidm/*.cmx
 %exclude %{_libdir}/ocaml/uuidm/*.mli
+%exclude %{_libdir}/ocaml/uuidm/*.annot
+%exclude %{_libdir}/ocaml/uuidm/*.cmt
+%exclude %{_libdir}/ocaml/uuidm/*.cmti
 
 %files devel
 %{_libdir}/ocaml/uuidm/*.a
@@ -55,6 +58,9 @@ rm -f %{buildroot}/%{_libdir}/ocaml/usr/local/bin/uuidtrip
 %{_libdir}/ocaml/uuidm/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.9.5-4
+- Remove *.cmt, *.cmti and *.annot
+
 * Mon Jun 02 2014 Euan Harris <euan.harris@citrix.com> - 0.9.5-3
 - Split files correctly between base and devel packages
 

--- a/SPECS/ocaml-uutf.spec
+++ b/SPECS/ocaml-uutf.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-uutf
 Version:        0.9.3
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        Non-blocking streaming codec for UTF-8, UTF-16, UTF-16LE and UTF-16BE
 License:        BSD3
 URL:            http://erratique.ch/software/uutf
@@ -48,6 +48,9 @@ mkdir -p %{buildroot}%{_libdir}/ocaml/uutf
 %{_libdir}/ocaml/uutf/META
 %{_libdir}/ocaml/uutf/uutf.cmi
 %{_libdir}/ocaml/uutf/uutf.cma
+%exclude %{_libdir}/ocaml/uutf/META/*.annot
+%exclude %{_libdir}/ocaml/uutf/META/*.cmt
+%exclude %{_libdir}/ocaml/uutf/META/*.cmti
 
 %files devel
 %{_libdir}/ocaml/uutf/uutf.cmx
@@ -58,6 +61,9 @@ mkdir -p %{buildroot}%{_libdir}/ocaml/uutf
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.9.3-4
+- Remove *.cmt, *.cmti and *.annot
+
 * Mon May 19 2014 Euan Harris <euan.harris@citrix.com> - 0.9.3-3
 - Switch to GitHub mirror
 

--- a/SPECS/ocaml-variantslib.spec
+++ b/SPECS/ocaml-variantslib.spec
@@ -3,7 +3,7 @@
 
 Name:           ocaml-variantslib
 Version:        109.15.02
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        OCaml variants as first class values
 
 Group:          Development/Libraries
@@ -81,6 +81,9 @@ rm -rf $RPM_BUILD_ROOT
 %exclude %{_libdir}/ocaml/variantslib/*.cmxa
 %endif
 %exclude %{_libdir}/ocaml/variantslib/*.mli
+%exclude %{_libdir}/ocaml/variantslib/*.annot
+%exclude %{_libdir}/ocaml/variantslib/*.cmt
+%exclude %{_libdir}/ocaml/variantslib/*.cmti
 
 
 %files devel
@@ -94,5 +97,8 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 109.15.02-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Wed Jan 01 2014 Edvard Fagerholm <edvard.fagerholm@gmail.com> - 109.15.02-1
 - Initial package for Fedora 20.

--- a/SPECS/ocaml-vhd.spec
+++ b/SPECS/ocaml-vhd.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-vhd
 Version:        0.7.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Pure OCaml library for reading, writing, streaming, converting vhd format files
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/djs55/ocaml-vhd
@@ -73,6 +73,9 @@ ocaml setup.ml -install
 %exclude %{_libdir}/ocaml/vhd-format/*.cmx
 %exclude %{_libdir}/ocaml/vhd-format/*.ml
 %exclude %{_libdir}/ocaml/vhd-format/*.mli
+%exclude %{_libdir}/ocaml/vhd-format/*.annot
+%exclude %{_libdir}/ocaml/vhd-format/*.cmt
+%exclude %{_libdir}/ocaml/vhd-format/*.cmti
 
 
 %files devel
@@ -83,6 +86,9 @@ ocaml setup.ml -install
 
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 0.7.3-5
+- Remove *.cmt, *.cmti and *.annot
+
 * Fri Jun 24 2016 Christian Lindig <christian.lindig@citrix.com> - 0.7.3-4
 - drop the previous patch because it contained a bug: when
   lseek(SEEK_HOLE) is retried, the offset must be 0, not c_ofs.

--- a/SPECS/ocaml-xenstore.spec
+++ b/SPECS/ocaml-xenstore.spec
@@ -1,12 +1,12 @@
 %global debug_package %{nil}
 
 Name:           ocaml-xenstore
-Version:        1.2.4
-Release:        2%{?dist}
+Version:        1.2.6
+Release:        1%{?dist}
 Summary:        Xenstore protocol implementation in OCaml
 License:        LGPL
 URL:            https://github.com/mirage/ocaml-xenstore
-Source0:        https://github.com/mirage/%{name}/archive/%{version}/%{name}-%{version}.tar.gz
+Source0:        https://github.com/mirage/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
 BuildRequires:  ocaml-cstruct-devel
@@ -59,6 +59,9 @@ make install
 %{_libdir}/ocaml/xenstore/*.mli
 
 %changelog
+* Mon Jun 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2.6-1
+- Update to 1.2.6
+
 * Mon Jun  2 2014 Euan Harris <euan.harris@citrix.com> - 1.2.4-2
 - Split files correctly between base and devel packages
 

--- a/SPECS/ocaml-xenstore.spec
+++ b/SPECS/ocaml-xenstore.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-xenstore
 Version:        1.2.6
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Xenstore protocol implementation in OCaml
 License:        LGPL
 URL:            https://github.com/mirage/ocaml-xenstore
@@ -51,6 +51,9 @@ make install
 %exclude %{_libdir}/ocaml/xenstore/*.cmxa
 %exclude %{_libdir}/ocaml/xenstore/*.cmx
 %exclude %{_libdir}/ocaml/xenstore/*.mli
+%exclude %{_libdir}/ocaml/xenstore/*.annot
+%exclude %{_libdir}/ocaml/xenstore/*.cmt
+%exclude %{_libdir}/ocaml/xenstore/*.cmti
 
 %files devel
 %{_libdir}/ocaml/xenstore/*.a
@@ -59,6 +62,9 @@ make install
 %{_libdir}/ocaml/xenstore/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2.6-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Mon Jun 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2.6-1
 - Update to 1.2.6
 

--- a/SPECS/ocaml-xmlm.spec
+++ b/SPECS/ocaml-xmlm.spec
@@ -1,6 +1,6 @@
 Name:           ocaml-xmlm
 Version:        1.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Streaming XML input/output for OCaml
 License:        BSD3
 URL:            http://erratique.ch/software/xmlm
@@ -49,6 +49,9 @@ cp _build/pkg/META  _build/src/xmlm.a  _build/src/xmlm.cma  _build/src/xmlm.cmi 
 %exclude %{_libdir}/ocaml/xmlm/*.cmxa
 %exclude %{_libdir}/ocaml/xmlm/*.cmx
 %exclude %{_libdir}/ocaml/xmlm/*.mli
+%exclude %{_libdir}/ocaml/xmlm/*.annot
+%exclude %{_libdir}/ocaml/xmlm/*.cmt
+%exclude %{_libdir}/ocaml/xmlm/*.cmti
 
 %files devel
 %{_libdir}/ocaml/xmlm/*.a
@@ -57,6 +60,9 @@ cp _build/pkg/META  _build/src/xmlm.a  _build/src/xmlm.cma  _build/src/xmlm.cmi 
 %{_libdir}/ocaml/xmlm/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.2.0-2
+- Remove *.cmt, *.cmti and *.annot
+
 * Thu Jul 17 2014 David Scott <dave.scott@citri.com> - 1.2.0-1
 - Update to 1.2.0
 

--- a/SPECS/ocaml-yojson.spec
+++ b/SPECS/ocaml-yojson.spec
@@ -2,7 +2,7 @@
 
 Name:           ocaml-yojson
 Version:        1.1.6
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A JSON parser and printer for OCaml
 License:        BSD3
 URL:            http://mjambon.com/yojson.html
@@ -45,12 +45,18 @@ make install DESTDIR=%{buildroot} BINDIR=%{buildroot}/%{_bindir}
 %{_libdir}/ocaml/yojson
 %exclude %{_libdir}/ocaml/yojson/*.cmx
 %exclude %{_libdir}/ocaml/yojson/*.mli
+%exclude %{_libdir}/ocaml/yojson/*.annot
+%exclude %{_libdir}/ocaml/yojson/*.cmt
+%exclude %{_libdir}/ocaml/yojson/*.cmti
 
 %files devel
 %{_libdir}/ocaml/yojson/*.cmx
 %{_libdir}/ocaml/yojson/*.mli
 
 %changelog
+* Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.1.6-4
+- Remove *.cmt, *.cmti and *.annot
+
 * Tue Oct 21 2014 Euan Harris <euan.harris@citrix.com> - 1.1.6-3
 - Switch to GitHub sources
 


### PR DESCRIPTION
Main change is to remove .cmt files from packages.  This reduces the number of files which must be installed when preparing a mock chroot.
