### PR TITLE
ocaml-vhd: add CA-218219 patch

### DIFF
--- a/SOURCES/0002-CA-218219-precheck-index-range-before-accessing.patch
+++ b/SOURCES/0002-CA-218219-precheck-index-range-before-accessing.patch
@@ -1,0 +1,31 @@
+From 4ac37887ad9b1b66053436f41deaf519bd5493df Mon Sep 17 00:00:00 2001
+From: Zheng Li <zheng.li3@citrix.com>
+Date: Wed, 7 Sep 2016 17:52:01 +0100
+Subject: [PATCH] CA-218219: precheck index range before accessing
+
+This is similar to the CA-139732 case fixed previously, just a different
+occurence. Basically, when there is a chain of VHDs of different sizes (i.e.
+there was resize operation in history), we'd better check if the index is in
+range before accessing the data.
+
+Signed-off-by: Zheng Li <zheng.li3@citrix.com>
+---
+ lib/f.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/f.ml b/lib/f.ml
+index d62f9c1..3d4bdf9 100644
+--- a/lib/f.ml
++++ b/lib/f.ml
+@@ -2093,7 +2093,7 @@ module From_file = functor(F: S.FILE) -> struct
+         let from_branch = make from in
+         let to_include = BATS.(union (diff t_branch from_branch) (diff from_branch t_branch)) in
+         fun i ->
+-          BATS.fold (fun (_, bat) acc -> acc || (BAT.get bat i <> BAT.unused)) to_include false
++          BATS.fold (fun (_, bat) acc -> acc || (i < BAT.length bat && BAT.get bat i <> BAT.unused)) to_include false
+ 
+   let raw_common ?from ?(raw: 'a) (vhd: fd Vhd.t) =
+     let block_size_sectors_shift = vhd.Vhd.header.Header.block_size_sectors_shift in
+-- 
+2.9.3
+

--- a/SPECS/ocaml-vhd.spec
+++ b/SPECS/ocaml-vhd.spec
@@ -2,12 +2,13 @@
 
 Name:           ocaml-vhd
 Version:        0.7.3
-Release:        5%{?dist}
+Release:        6%{?dist}
 Summary:        Pure OCaml library for reading, writing, streaming, converting vhd format files
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/djs55/ocaml-vhd
 Source0:        https://github.com/djs55/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 Patch0:         0001-CA-212154-retry-if-lseek-2-doesn-t-support-SEEK_DATA.patch
+Patch1:         0002-CA-218219-precheck-index-range-before-accessing.patch
 
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
@@ -48,6 +49,7 @@ developing applications that use %{name}.
 %prep
 %setup -q
 %patch0 -p1
+%patch1 -p1
 
 %build
 if [ -x ./configure ]; then


### PR DESCRIPTION
This patch fixes CA-218219 (VDI.copy/sparse_dd fails on some SR types when src VDI and base VDI have different sizes). Basically we need to precheck index range before accessing the data.

Signed-off-by: Zheng Li zheng.li3@citrix.com
