### PR TITLE
ocaml-ppx-devel, ocaml-findlib: Solve compilation issues

### DIFF
--- a/SPECS/ocaml-findlib.spec
+++ b/SPECS/ocaml-findlib.spec
@@ -5,8 +5,8 @@
 %endif
 
 Name:           ocaml-findlib
-Version:        1.5.5
-Release:        2%{?extrarelease}
+Version:        1.6.3
+Release:        1%{?extrarelease}
 Summary:        Objective CAML package manager and build helper
 
 Group:          Development/Libraries
@@ -127,6 +127,9 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Tue Oct 25 2016 Marcello Seri <marcello.seri@citrix.com> - 1.6.3-1
+- Update to 1.6.3 for findlib.dynload
+
 * Wed Jul 27 2016 Euan Harris <euan.harris@citrix.com> - 1.5.5-2
 - Remove *.cmt, *.cmti and *.annot
 

--- a/SPECS/ocaml-ppx-deriving.spec
+++ b/SPECS/ocaml-ppx-deriving.spec
@@ -8,11 +8,11 @@ License:        MIT
 URL:            https://github.com/whitequark/ppx_deriving
 Source0:        https://github.com/whitequark/ppx_deriving/archive/v%{version}/%{name}-%{version}.tar.gz
 BuildRequires:  ocaml
-BuildRequires:  ocaml-findlib
-BuildRequires:  cppo
+BuildRequires:  ocaml-findlib-devel
+BuildRequires:  cppo-devel
 BuildRequires:  ocaml-ounit
 BuildRequires:  ocaml-result-devel
-BuildRequires:  ocaml-ppx-tools
+BuildRequires:  ocaml-ppxtools-devel
 
 %description
 deriving is a library simplifying type-driven code generation on OCaml


### PR DESCRIPTION
This updates the build dependencies of ppx-deriving to compile in our build system
