### PR TITLE
CA-244698: backport CA-218219 fix: precheck index range before accessing

### DIFF
--- a/SOURCES/ocaml-vhd-CA-218219.patch
+++ b/SOURCES/ocaml-vhd-CA-218219.patch
@@ -1,0 +1,31 @@
+From 603ea4d8bb0b101b7efa30ccb7ed22028cd4ffbe Mon Sep 17 00:00:00 2001
+From: Zheng Li <zheng.li3@citrix.com>
+Date: Wed, 7 Sep 2016 17:52:01 +0100
+Subject: [PATCH] CA-218219: precheck index range before accessing
+
+This is similar to the CA-139732 case fixed previously, just a different
+occurence. Basically, when there is a chain of VHDs of different sizes (i.e.
+there was resize operation in history), we'd better check if the index is in
+range before accessing the data.
+
+Signed-off-by: Zheng Li <zheng.li3@citrix.com>
+---
+ lib/f.ml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/f.ml b/lib/f.ml
+index 620600f..7da5452 100644
+--- a/lib/f.ml
++++ b/lib/f.ml
+@@ -2093,7 +2093,7 @@ module From_file = functor(F: S.FILE) -> struct
+         let from_branch = make from in
+         let to_include = BATS.(union (diff t_branch from_branch) (diff from_branch t_branch)) in
+         fun i ->
+-          BATS.fold (fun (_, bat) acc -> acc || (BAT.get bat i <> BAT.unused)) to_include false
++          BATS.fold (fun (_, bat) acc -> acc || (i < BAT.length bat && BAT.get bat i <> BAT.unused)) to_include false
+ 
+   let raw_common ?from ?(raw: 'a) (vhd: fd Vhd.t) =
+     let block_size_sectors_shift = vhd.Vhd.header.Header.block_size_sectors_shift in
+-- 
+2.7.4
+

--- a/SPECS/ocaml-vhd.spec
+++ b/SPECS/ocaml-vhd.spec
@@ -2,12 +2,13 @@
 
 Name:           ocaml-vhd
 Version:        0.7.3
-Release:        4%{?dist}
+Release:        5%{?dist}
 Summary:        Pure OCaml library for reading, writing, streaming, converting vhd format files
 License:        LGPL2.1 + OCaml linking exception
 URL:            https://github.com/djs55/ocaml-vhd
 Source0:        https://github.com/djs55/%{name}/archive/v%{version}/%{name}-%{version}.tar.gz
 Patch0:         0001-CA-212154-retry-if-lseek-2-doesn-t-support-SEEK_DATA.patch
+Patch1:         ocaml-vhd-CA-218219.patch
 
 BuildRequires:  ocaml
 BuildRequires:  ocaml-camlp4-devel
@@ -48,6 +49,7 @@ developing applications that use %{name}.
 %prep
 %setup -q
 %patch0 -p1
+%patch1 -p1 -b ~ocaml-vhd-CA-218219.patch
 
 %build
 if [ -x ./configure ]; then
@@ -83,6 +85,9 @@ ocaml setup.ml -install
 
 
 %changelog
+* Thu Mar 23 2017 Frederico Mazzone <frederico.mazzone@citrix.com> - 0.7.3-5
+- CA-244698: backport CA-218219 fix: Check index range before accessing
+
 * Fri Jun 24 2016 Christian Lindig <christian.lindig@citrix.com> - 0.7.3-4
 - drop the previous patch because it contained a bug: when
   lseek(SEEK_HOLE) is retried, the offset must be 0, not c_ofs.


### PR DESCRIPTION
Create new ocaml-vhd release to be used in new vhd-tool release.

Signed-off-by: Frederico Mazzone <frederico.mazzone@citrix.com>